### PR TITLE
Small cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ mongobetween -network unix \
 
 The `label` query parameter in the connection URI is used to any tag statsd metrics or logs for that connection.
 
+### TODO
+
+Current known missing features:
+ - [ ] Transaction server pinning
+ - [ ] Unacked writes (one-way messages)
+ - [ ] Different cursors on separate servers with the same cursor ID value
+
 ### Statsd
 `mongobetween` supports reporting health metrics to a local statsd sidecar, using the [Datadog Go library](github.com/DataDog/datadog-go). By default it reports to `localhost:8125`. The following metrics are reported:
  - `mongobetween.handle_message` (Timing) - round trip time of handling an incoming message from the application

--- a/mongo/ismaster.go
+++ b/mongo/ismaster.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
@@ -34,8 +33,6 @@ func IsMasterResponse(responseTo int32, topologyKind description.TopologyKind) (
 func isMasterDocument(kind description.TopologyKind) (bsoncore.Document, error) {
 	ns := time.Now().UnixNano()
 	ms := ns / 1e6
-	s := ns / 1e9
-	s32 := uint32(s) // :'( will break in 2038
 	var doc bson.D
 	if kind == description.Single {
 		doc = bson.D{
@@ -64,8 +61,6 @@ func isMasterDocument(kind description.TopologyKind) (bsoncore.Document, error) 
 			{Key: "minWireVersion", Value: 0},                            // $numberInt
 			{Key: "saslSupportedMechs", Value: bson.A{}},                 // empty (proxy doesn't support auth)
 			{Key: "ok", Value: 1.0},                                      // $numberDouble
-			{Key: "operationTime", Value: primitive.Timestamp{T: s32}},
-			{Key: "$clusterTime", Value: bson.D{{Key: "clusterTime", Value: primitive.Timestamp{T: s32}}}},
 		}
 	}
 	return bson.Marshal(doc)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -156,6 +156,7 @@ func (m *Mongo) RoundTrip(msg *Message) (*Message, error) {
 		return nil, errors.New("connection closed")
 	}
 
+	// FIXME currently this assumes that cursorIDs are unique on the cluster, but two servers can have the same cursorID reference different cursors
 	requestCursorID, _ := msg.Op.CursorID()
 	server, err := m.selectServer(requestCursorID)
 	if err != nil {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -175,6 +175,7 @@ func (m *Mongo) RoundTrip(msg *Message) (*Message, error) {
 		}
 	}()
 
+	// TODO add support for one-way messages (unacked writes)
 	wm, err := m.roundTrip(conn, msg.Wm)
 	if err != nil {
 		return nil, err

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -156,12 +156,14 @@ func (m *Mongo) RoundTrip(msg *Message) (*Message, error) {
 		return nil, errors.New("connection closed")
 	}
 
-	// FIXME currently this assumes that cursorIDs are unique on the cluster, but two servers can have the same cursorID reference different cursors
+	// FIXME this assumes that cursorIDs are unique on the cluster, but two servers can have the same cursorID reference different cursors
 	requestCursorID, _ := msg.Op.CursorID()
 	server, err := m.selectServer(requestCursorID)
 	if err != nil {
 		return nil, err
 	}
+
+	// FIXME transactions should be pinned to servers, similar to cursors above
 
 	conn, err := m.checkoutConnection(server)
 	if err != nil {

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -131,7 +131,7 @@ func (c *connection) readWireMessage() ([]byte, error) {
 func (c *connection) roundTrip(msg *mongo.Message, isMaster bool) (*mongo.Message, error) {
 	if isMaster {
 		requestID := msg.Op.RequestID()
-		c.log.Info("Non-proxied ismaster response", zap.Int32("request_id", requestID))
+		c.log.Debug("Non-proxied ismaster response", zap.Int32("request_id", requestID))
 		return mongo.IsMasterResponse(requestID, c.client.TopologyKind())
 	}
 

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -81,7 +81,7 @@ func (c *connection) handleMessage() (err error) {
 		return err
 	}
 
-	c.log.Debug("Message", zap.Int32("op_code", int32(op.OpCode())), zap.Int("request_size", len(wm)))
+	c.log.Debug("Request", zap.Int32("op_code", int32(op.OpCode())), zap.Int("request_size", len(wm)))
 
 	isMaster = op.IsIsMaster()
 	req := &mongo.Message{


### PR DESCRIPTION
Add comments about missing features:
 - unique cursorIDs per cluster, not per server
 - transaction server pinning
 - one-way messages (unacked writes)

Change `"Non-proxied ismaster response"` log message from `Info` to `Debug` (too noisy in production).

Remove `operationTime`/`$clusterTime` from `ismaster` response (not necessary).