### PR TITLE
Add topology monitoring

### DIFF
--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -71,8 +71,9 @@ func Connect(log *zap.Logger, sd *statsd.Client, opts *options.ClientOptions, pi
 	}
 
 	t := extractTopology(c)
-	rtCtx, rtCancel := context.WithCancel(context.Background())
+	go topologyMonitor(log, t)
 
+	rtCtx, rtCancel := context.WithCancel(context.Background())
 	m := Mongo{
 		log:             log,
 		statsd:          sd,

--- a/mongo/topology_monitor.go
+++ b/mongo/topology_monitor.go
@@ -1,0 +1,56 @@
+package mongo
+
+import (
+	"fmt"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/topology"
+	"go.uber.org/zap"
+	"time"
+)
+
+func topologyMonitor(log *zap.Logger, t *topology.Topology) {
+	last := t.Description()
+	for {
+		time.Sleep(5 * time.Second)
+		desc := t.Description()
+		if !topologyDescriptionEqual(&last, &desc) {
+			fields := []zap.Field{
+				zap.String("old_kind", last.Kind.String()),
+				zap.String("new_kind", desc.Kind.String()),
+			}
+			for i, s := range last.Servers {
+				fields = append(fields, zap.String(fmt.Sprintf("old_address_%d", i), s.Addr.String()))
+				fields = append(fields, zap.String(fmt.Sprintf("old_kind_%d", i), s.Kind.String()))
+			}
+			for i, s := range desc.Servers {
+				fields = append(fields, zap.String(fmt.Sprintf("new_address_%d", i), s.Addr.String()))
+				fields = append(fields, zap.String(fmt.Sprintf("new_kind_%d", i), s.Kind.String()))
+			}
+			log.Info("Topology changed", fields...)
+		}
+		last = desc
+	}
+}
+
+func topologyDescriptionEqual(d1, d2 *description.Topology) bool {
+	if d1.Kind != d2.Kind {
+		return false
+	}
+	s1 := make(map[string]description.ServerKind)
+	s2 := make(map[string]description.ServerKind)
+	for _, s := range d1.Servers {
+		s1[s.Addr.String()] = s.Kind
+	}
+	for _, s := range d2.Servers {
+		s2[s.Addr.String()] = s.Kind
+	}
+	if len(s1) != len(s2) {
+		return false
+	}
+	for k, v := range s1 {
+		if s2[k] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/mongo/topology_monitor_test.go
+++ b/mongo/topology_monitor_test.go
@@ -1,0 +1,35 @@
+package mongo
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
+	"testing"
+)
+
+func TestTopologyDescriptionEqual(t *testing.T) {
+	d1 := description.Topology{}
+	d2 := description.Topology{}
+	assert.True(t, topologyDescriptionEqual(&d1, &d2))
+
+	d1 = description.Topology{Kind: description.ReplicaSet}
+	d2 = description.Topology{Kind: description.ReplicaSetNoPrimary}
+	assert.False(t, topologyDescriptionEqual(&d1, &d2))
+
+	d1 = description.Topology{Servers: []description.Server{{Addr: "addr1", Kind: description.Standalone}}}
+	d2 = description.Topology{Servers: []description.Server{{Addr: "addr2", Kind: description.Standalone}}}
+	assert.False(t, topologyDescriptionEqual(&d1, &d2))
+
+	d1 = description.Topology{Servers: []description.Server{{Addr: "addr1", Kind: description.Standalone}}}
+	d2 = description.Topology{Servers: []description.Server{{Addr: "addr1", Kind: description.Mongos}}}
+	assert.False(t, topologyDescriptionEqual(&d1, &d2))
+
+	d1 = description.Topology{Servers: []description.Server{
+		{Addr: "addr1", Kind: description.Standalone},
+		{Addr: "addr2", Kind: description.Mongos},
+	}}
+	d2 = description.Topology{Servers: []description.Server{
+		{Addr: "addr2", Kind: description.Mongos},
+		{Addr: "addr1", Kind: description.Standalone},
+	}}
+	assert.True(t, topologyDescriptionEqual(&d1, &d2))
+}


### PR DESCRIPTION
In the absence of SDAM monitoring by the Go driver, this adds logging whenever the topology changes, checked every 5 seconds in a go routine.

Example logs from a failover:
```
2020-06-13T11:22:08.401-0700	INFO	mongo/topology_monitor.go:29	Topology changed	{"cluster": "default", "old_kind": "Sharded", "new_kind": "Sharded", "old_address_0": "localhost:27016", "old_kind_0": "Mongos", "old_address_1": "localhost:27017", "old_kind_1": "Mongos", "old_address_2": "localhost:27018", "old_kind_2": "Mongos", "old_address_3": "localhost:27019", "old_kind_3": "Mongos", "new_address_0": "localhost:27016", "new_kind_0": "Mongos", "new_address_1": "localhost:27017", "new_kind_1": "Unknown", "new_address_2": "localhost:27018", "new_kind_2": "Mongos", "new_address_3": "localhost:27019", "new_kind_3": "Mongos"}
2020-06-13T11:22:58.416-0700	INFO	mongo/topology_monitor.go:29	Topology changed	{"cluster": "default", "old_kind": "Sharded", "new_kind": "Sharded", "old_address_0": "localhost:27016", "old_kind_0": "Mongos", "old_address_1": "localhost:27017", "old_kind_1": "Unknown", "old_address_2": "localhost:27018", "old_kind_2": "Mongos", "old_address_3": "localhost:27019", "old_kind_3": "Mongos", "new_address_0": "localhost:27016", "new_kind_0": "Mongos", "new_address_1": "localhost:27017", "new_kind_1": "Mongos", "new_address_2": "localhost:27018", "new_kind_2": "Mongos", "new_address_3": "localhost:27019", "new_kind_3": "Mongos"}
```