### PR TITLE
Copy server error processing from driver

### DIFF
--- a/mongo/export_test.go
+++ b/mongo/export_test.go
@@ -1,0 +1,30 @@
+package mongo
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"testing"
+)
+
+func NewOpMsg(single bsoncore.Document, sequence []bsoncore.Document) *Message {
+	op := opMsg{
+		sections: []opMsgSection{
+			&opMsgSectionSingle{single},
+			&opMsgSectionSequence{
+				identifier: "documents",
+				msgs:       sequence,
+			},
+		},
+	}
+	wm := op.Encode(0)
+	return &Message{wm, &op}
+}
+
+func ExtractSingleOpMsg(t *testing.T, msg *Message) bsoncore.Document {
+	op, ok := msg.Op.(*opMsg)
+	assert.True(t, ok)
+	assert.Equal(t, 1, len(op.sections))
+	single, ok := op.sections[0].(*opMsgSectionSingle)
+	assert.True(t, ok)
+	return single.msg
+}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -184,6 +184,8 @@ func (m *Mongo) RoundTrip(msg *Message) (*Message, error) {
 		// see https://github.com/mongodb/mongo-go-driver/blob/v1.3.4/x/mongo/driver/operation.go#L369-L371
 		if ep, ok := server.(driver.ErrorProcessor); ok {
 			ep.ProcessError(err)
+		} else {
+			m.log.Warn("ErrorProcessor type assertion failed")
 		}
 		return nil, err
 	}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -117,8 +117,8 @@ func poolMonitor(sd *statsd.Client) *event.PoolMonitor {
 	}
 }
 
-func (m *Mongo) TopologyKind() description.TopologyKind {
-	return m.topology.Kind()
+func (m *Mongo) Description() description.Topology {
+	return m.topology.Description()
 }
 
 func (m *Mongo) cursorMonitor() {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -181,6 +181,10 @@ func (m *Mongo) RoundTrip(msg *Message) (*Message, error) {
 	// TODO add support for one-way messages (unacked writes)
 	wm, err := m.roundTrip(conn, msg.Wm)
 	if err != nil {
+		// see https://github.com/mongodb/mongo-go-driver/blob/v1.3.4/x/mongo/driver/operation.go#L369-L371
+		if ep, ok := server.(driver.ErrorProcessor); ok {
+			ep.ProcessError(err)
+		}
 		return nil, err
 	}
 
@@ -242,6 +246,7 @@ func (m *Mongo) checkoutConnection(server driver.Server) (conn driver.Connection
 	return conn, nil
 }
 
+// see https://github.com/mongodb/mongo-go-driver/blob/v1.3.4/x/mongo/driver/operation.go#L532-L561
 func (m *Mongo) roundTrip(conn driver.Connection, req []byte) (res []byte, err error) {
 	defer func(start time.Time) {
 		addressTag := fmt.Sprintf("address:%s", conn.Address().String())
@@ -252,9 +257,18 @@ func (m *Mongo) roundTrip(conn driver.Connection, req []byte) (res []byte, err e
 		_ = m.statsd.Timing("round_trip", time.Since(start), []string{addressTag, fmt.Sprintf("success:%v", err == nil)}, 1)
 	}(time.Now())
 
-	err = conn.WriteWireMessage(m.roundTripCtx, req)
-	if err != nil {
-		return nil, err
+	if err = conn.WriteWireMessage(m.roundTripCtx, req); err != nil {
+		return nil, wrapNetworkError(err)
 	}
-	return conn.ReadWireMessage(m.roundTripCtx, req[:0])
+
+	if res, err = conn.ReadWireMessage(m.roundTripCtx, req[:0]); err != nil {
+		return nil, wrapNetworkError(err)
+	}
+
+	return res, nil
+}
+
+func wrapNetworkError(err error) error {
+	labels := []string{driver.NetworkError}
+	return driver.Error{Message: err.Error(), Labels: labels, Wrapped: err}
 }

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -1,30 +1,22 @@
-package mongo
+package mongo_test
 
 import (
 	"github.com/DataDog/datadog-go/statsd"
+	"github.com/coinbase/mongobetween/mongo"
+	"github.com/coinbase/mongobetween/proxy"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"go.mongodb.org/mongo-driver/x/mongo/driver/description"
 	"go.uber.org/zap"
 	"os"
 	"testing"
 )
 
-func TestRoundTrip(t *testing.T) {
-	uri := "mongodb://localhost:27017/test"
-	if os.Getenv("CI") == "true" {
-		uri = "mongodb://mongo:27017/test"
-	}
-
-	sd, err := statsd.New("localhost:8125")
-	assert.Nil(t, err)
-
-	clientOptions := options.Client().ApplyURI(uri)
-	m, err := Connect(zap.L(), sd, clientOptions, false)
-	assert.Nil(t, err)
-
+func insertOpMsg(t *testing.T) *mongo.Message {
 	insert, err := bson.Marshal(bson.D{
 		{Key: "insert", Value: "trainers"},
 		{Key: "$db", Value: "test"},
@@ -47,24 +39,72 @@ func TestRoundTrip(t *testing.T) {
 	})
 	assert.Nil(t, err)
 
-	op := opMsg{
-		sections: []opMsgSection{
-			&opMsgSectionSingle{insert},
-			&opMsgSectionSequence{
-				identifier: "documents",
-				msgs:       []bsoncore.Document{doc1, doc2},
-			},
-		},
-	}
-	wm := op.Encode(0)
+	return mongo.NewOpMsg(insert, []bsoncore.Document{doc1, doc2})
+}
 
-	res, err := m.RoundTrip(&Message{wm, &op})
+func TestRoundTrip(t *testing.T) {
+	uri := "mongodb://localhost:27017/test"
+	if os.Getenv("CI") == "true" {
+		uri = "mongodb://mongo:27017/test"
+	}
+
+	sd, err := statsd.New("localhost:8125")
 	assert.Nil(t, err)
 
-	msg := res.Op.(*opMsg)
-	assert.Equal(t, 1, len(msg.sections))
-	single := msg.sections[0].(*opMsgSectionSingle)
+	clientOptions := options.Client().ApplyURI(uri)
+	m, err := mongo.Connect(zap.L(), sd, clientOptions, false)
+	assert.Nil(t, err)
 
-	assert.Equal(t, int32(2), single.msg.Lookup("n").Int32())
-	assert.Equal(t, 1.0, single.msg.Lookup("ok").Double())
+	msg := insertOpMsg(t)
+
+	res, err := m.RoundTrip(msg)
+	assert.Nil(t, err)
+
+	single := mongo.ExtractSingleOpMsg(t, res)
+
+	assert.Equal(t, int32(2), single.Lookup("n").Int32())
+	assert.Equal(t, 1.0, single.Lookup("ok").Double())
+}
+
+func TestRoundTripProcessError(t *testing.T) {
+	uri := "mongodb://localhost:27017/test"
+	if os.Getenv("CI") == "true" {
+		uri = "mongodb://mongo:27017/test"
+	}
+
+	sd, err := statsd.New("localhost:8125")
+	assert.Nil(t, err)
+
+	opts := options.Client().ApplyURI(uri)
+	p, err := proxy.NewProxy(zap.L(), sd, "label", "tcp4", ":27019", false, true, opts)
+	assert.Nil(t, err)
+
+	go func() {
+		err := p.Run()
+		assert.Nil(t, err)
+	}()
+
+	clientOptions := options.Client().ApplyURI("mongodb://localhost:27019/test")
+	m, err := mongo.Connect(zap.L(), sd, clientOptions, false)
+	assert.Nil(t, err)
+
+	msg := insertOpMsg(t)
+
+	res, err := m.RoundTrip(msg)
+	assert.Nil(t, err)
+
+	single := mongo.ExtractSingleOpMsg(t, res)
+
+	assert.Equal(t, int32(2), single.Lookup("n").Int32())
+	assert.Equal(t, 1.0, single.Lookup("ok").Double())
+
+	assert.Equal(t, description.Standalone, m.Description().Servers[0].Kind)
+
+	// kill the proxy
+	p.Kill()
+
+	_, err = m.RoundTrip(msg)
+	assert.Error(t, driver.Error{}, err)
+
+	assert.Equal(t, description.ServerKind(description.Unknown), m.Description().Servers[0].Kind, "Failed to update the server Kind to Unknown")
 }

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -140,7 +140,7 @@ func (c *connection) roundTrip(msg *mongo.Message, isMaster bool) (*mongo.Messag
 	if isMaster {
 		requestID := msg.Op.RequestID()
 		c.log.Debug("Non-proxied ismaster response", zap.Int32("request_id", requestID))
-		return mongo.IsMasterResponse(requestID, c.client.TopologyKind())
+		return mongo.IsMasterResponse(requestID, c.client.Description().Kind)
 	}
 
 	c.log.Debug("Proxying request to upstream server", zap.Int("request_size", len(msg.Wm)))


### PR DESCRIPTION
We weren't calling `server.ProcessError` on any round trip errors. This means that any connection errors wouldn't mark the server as unknown, extending failures.

This PR adds the `server.ProcessError` call, and duplicates the wrapping of the error in a `driver.Error` just as `driver.Operation` does in the Go driver.