### PR TITLE
Process errors returned by the server

### DIFF
--- a/mongo/operations_test.go
+++ b/mongo/operations_test.go
@@ -113,6 +113,24 @@ func TestOpMsgCursorID(t *testing.T) {
 	assert.Equal(t, int64(103), cursorID)
 }
 
+func TestOpMsgNoError(t *testing.T) {
+	doc1, err := bson.Marshal(bson.D{{Key: "getMore", Value: int64(102)}, {Key: "ok", Value: int32(1)}})
+	assert.Nil(t, err)
+
+	op := opMsg{sections: []opMsgSection{&opMsgSectionSingle{doc1}}}
+	err = op.Error()
+	assert.Nil(t, err)
+}
+
+func TestOpMsgError(t *testing.T) {
+	doc1, err := bson.Marshal(bson.D{{Key: "code", Value: int32(11600)}})
+	assert.Nil(t, err)
+
+	op := opMsg{sections: []opMsgSection{&opMsgSectionSingle{doc1}}}
+	err = op.Error()
+	assert.Error(t, err)
+}
+
 func TestOpReply(t *testing.T) {
 	doc1, err := bson.Marshal(bson.D{{Key: "name", Value: "Misty"}})
 	assert.Nil(t, err)


### PR DESCRIPTION
Follow up to #8.

@divjotarora rightly pointed out that we're not processing any errors within the server response itself (for example, `interrupted at shutdown (11600)` during failover).

This PR introduces this processing, copying the `extractError` function directly from https://github.com/mongodb/mongo-go-driver/blob/v1.3.4/x/mongo/driver/errors.go#L290-L409.