### PR TITLE
Fake an InterruptedDueToStepDown error on upstream topology-affecting errors 

### DIFF
--- a/mongo/interrupted_due_to_shutdown.go
+++ b/mongo/interrupted_due_to_shutdown.go
@@ -1,0 +1,33 @@
+package mongo
+
+import (
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+)
+
+// hard-coded response, emulating an InterruptedDueToStepDown error which doesn't drain the downstream connection pool
+func InterruptedDueToShutdownResponse(responseTo int32) (*Message, error) {
+	doc, err := interruptedDueToShutdownDocument()
+	if err != nil {
+		return nil, err
+	}
+	op := opMsg{
+		sections: []opMsgSection{&opMsgSectionSingle{
+			msg: doc,
+		}},
+	}
+	wm := op.Encode(responseTo)
+	return &Message{
+		Wm: wm,
+		Op: &op,
+	}, nil
+}
+
+func interruptedDueToShutdownDocument() (bsoncore.Document, error) {
+	return bson.Marshal(bson.D{
+		{Key: "ok", Value: 0},
+		{Key: "code", Value: 11602},
+		{Key: "codeName", Value: "InterruptedDueToStepDown"},
+		{Key: "errmsg", Value: "interrupted due to shutdown"},
+	})
+}


### PR DESCRIPTION
Fixes #16.

Returns a fake `InterruptedDueToStepDown` error (code `11602`) to the downstream application if the upstream server causes errors that would change the topology. This is to ensure that the application's view of the `mongobetween` server remains unchanged, and the connection pool isn't drained for no reason.

```json
{
  "ok": 0,
  "code": 11602,
  "codeName": "InterruptedDueToStepDown",
  "errmsg": "interrupted due to shutdown"
}
```