### PR TITLE
Improved observability into operations

### DIFF
--- a/mongo/command.go
+++ b/mongo/command.go
@@ -32,7 +32,7 @@ const (
 	Update            Command = "update"
 )
 
-var collectionStrings = []Command{Aggregate, Count, CreateIndexes, Delete, Distinct, Drop, DropIndexes, Find, FindAndModify, Insert, ListIndexes, MapReduce, Update}
+var collectionCommands = []Command{Aggregate, Count, CreateIndexes, Delete, Distinct, Drop, DropIndexes, Find, FindAndModify, Insert, ListIndexes, MapReduce, Update}
 var int32Commands = []Command{AbortTransaction, Aggregate, CommitTransaction, DropDatabase, IsMaster, Ismaster, ListCollections, ListDatabases}
 var int64Commands = []Command{GetMore}
 var arrayCommands = []Command{EndSessions}
@@ -46,7 +46,7 @@ func IsWrite(command Command) bool {
 }
 
 func CommandAndCollection(msg bsoncore.Document) (Command, string) {
-	for _, s := range collectionStrings {
+	for _, s := range collectionCommands {
 		if coll, ok := msg.Lookup(string(s)).StringValueOK(); ok {
 			return s, coll
 		}

--- a/mongo/command.go
+++ b/mongo/command.go
@@ -8,28 +8,28 @@ type Command string
 
 const (
 	Unknown           Command = "unknown"
-	AbortTransaction          = "abortTransaction"
-	Aggregate                 = "aggregate"
-	CommitTransaction         = "commandTransaction"
-	Count                     = "count"
-	CreateIndexes             = "createIndexes"
-	Delete                    = "delete"
-	Distinct                  = "distinct"
-	Drop                      = "drop"
-	DropDatabase              = "dropDatabase"
-	DropIndexes               = "dropIndexes"
-	EndSessions               = "endSessions"
-	Find                      = "find"
-	FindAndModify             = "findAndModify"
-	GetMore                   = "getMore"
-	Insert                    = "insert"
-	IsMaster                  = "isMaster"
-	Ismaster                  = "ismaster"
-	ListCollections           = "listCollections"
-	ListIndexes               = "listIndexes"
-	ListDatabases             = "listDatabases"
-	MapReduce                 = "mapReduce"
-	Update                    = "update"
+	AbortTransaction  Command = "abortTransaction"
+	Aggregate         Command = "aggregate"
+	CommitTransaction Command = "commandTransaction"
+	Count             Command = "count"
+	CreateIndexes     Command = "createIndexes"
+	Delete            Command = "delete"
+	Distinct          Command = "distinct"
+	Drop              Command = "drop"
+	DropDatabase      Command = "dropDatabase"
+	DropIndexes       Command = "dropIndexes"
+	EndSessions       Command = "endSessions"
+	Find              Command = "find"
+	FindAndModify     Command = "findAndModify"
+	GetMore           Command = "getMore"
+	Insert            Command = "insert"
+	IsMaster          Command = "isMaster"
+	Ismaster          Command = "ismaster"
+	ListCollections   Command = "listCollections"
+	ListIndexes       Command = "listIndexes"
+	ListDatabases     Command = "listDatabases"
+	MapReduce         Command = "mapReduce"
+	Update            Command = "update"
 )
 
 var collectionStrings = []Command{Aggregate, Count, CreateIndexes, Delete, Distinct, Drop, DropIndexes, Find, FindAndModify, Insert, ListIndexes, MapReduce, Update}
@@ -73,7 +73,7 @@ func CommandAndCollection(msg bsoncore.Document) (Command, string) {
 }
 
 func IsIsMasterDoc(doc bsoncore.Document) bool {
-	isMaster, _ := doc.Lookup(IsMaster).Int32OK()
-	ismaster, _ := doc.Lookup(Ismaster).Int32OK()
+	isMaster, _ := doc.Lookup(string(IsMaster)).Int32OK()
+	ismaster, _ := doc.Lookup(string(Ismaster)).Int32OK()
 	return ismaster+isMaster > 0
 }

--- a/mongo/command.go
+++ b/mongo/command.go
@@ -1,0 +1,79 @@
+package mongo
+
+import (
+	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
+	"strings"
+)
+
+type Command string
+
+const (
+	Unknown           Command = "unknown"
+	AbortTransaction          = "abortTransaction"
+	Aggregate                 = "aggregate"
+	CommitTransaction         = "commandTransaction"
+	Count                     = "count"
+	CreateIndexes             = "createIndexes"
+	Delete                    = "delete"
+	Distinct                  = "distinct"
+	Drop                      = "drop"
+	DropDatabase              = "dropDatabase"
+	DropIndexes               = "dropIndexes"
+	EndSessions               = "endSessions"
+	Find                      = "find"
+	FindAndModify             = "findAndModify"
+	GetMore                   = "getMore"
+	Insert                    = "insert"
+	IsMaster                  = "isMaster"
+	ListCollections           = "listCollections"
+	ListIndexes               = "listIndexes"
+	ListDatabases             = "listDatabases"
+	MapReduce                 = "mapReduce"
+	Update                    = "update"
+)
+
+var collectionStrings = []Command{Aggregate, Count, CreateIndexes, Delete, Distinct, Drop, DropIndexes, Find, FindAndModify, Insert, ListIndexes, MapReduce, Update}
+var int32Commands = []Command{AbortTransaction, Aggregate, CommitTransaction, DropDatabase, IsMaster, ListCollections, ListDatabases}
+var int64Commands = []Command{GetMore}
+var arrayCommands = []Command{EndSessions}
+
+func IsWrite(command Command) bool {
+	switch command {
+	case CommitTransaction, CreateIndexes, Delete, Drop, DropIndexes, DropDatabase, FindAndModify, Insert, Update:
+		return true
+	}
+	return false
+}
+
+func CommandAndCollection(msg bsoncore.Document) (Command, string) {
+	for _, s := range collectionStrings {
+		if coll, ok := msg.Lookup(string(s)).StringValueOK(); ok {
+			return s, coll
+		}
+	}
+	for _, s := range int32Commands {
+		value := msg.Lookup(string(s))
+		if value.Data != nil {
+			return s, ""
+		}
+	}
+	for _, s := range int64Commands {
+		value := msg.Lookup(string(s))
+		if value.Data != nil {
+			return s, ""
+		}
+	}
+	for _, s := range arrayCommands {
+		value := msg.Lookup(string(s))
+		if value.Data != nil {
+			return s, ""
+		}
+	}
+	return Unknown, ""
+}
+
+func IsIsMasterDoc(doc bsoncore.Document) bool {
+	isMaster, _ := doc.Lookup(IsMaster).Int32OK()
+	ismaster, _ := doc.Lookup(strings.ToLower(IsMaster)).Int32OK()
+	return ismaster+isMaster > 0
+}

--- a/mongo/command.go
+++ b/mongo/command.go
@@ -2,7 +2,6 @@ package mongo
 
 import (
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
-	"strings"
 )
 
 type Command string
@@ -25,6 +24,7 @@ const (
 	GetMore                   = "getMore"
 	Insert                    = "insert"
 	IsMaster                  = "isMaster"
+	Ismaster                  = "ismaster"
 	ListCollections           = "listCollections"
 	ListIndexes               = "listIndexes"
 	ListDatabases             = "listDatabases"
@@ -33,7 +33,7 @@ const (
 )
 
 var collectionStrings = []Command{Aggregate, Count, CreateIndexes, Delete, Distinct, Drop, DropIndexes, Find, FindAndModify, Insert, ListIndexes, MapReduce, Update}
-var int32Commands = []Command{AbortTransaction, Aggregate, CommitTransaction, DropDatabase, IsMaster, ListCollections, ListDatabases}
+var int32Commands = []Command{AbortTransaction, Aggregate, CommitTransaction, DropDatabase, IsMaster, Ismaster, ListCollections, ListDatabases}
 var int64Commands = []Command{GetMore}
 var arrayCommands = []Command{EndSessions}
 
@@ -74,6 +74,6 @@ func CommandAndCollection(msg bsoncore.Document) (Command, string) {
 
 func IsIsMasterDoc(doc bsoncore.Document) bool {
 	isMaster, _ := doc.Lookup(IsMaster).Int32OK()
-	ismaster, _ := doc.Lookup(strings.ToLower(IsMaster)).Int32OK()
+	ismaster, _ := doc.Lookup(Ismaster).Int32OK()
 	return ismaster+isMaster > 0
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -160,12 +160,15 @@ func (m *Mongo) RoundTrip(msg *Message) (_ *Message, err error) {
 	defer func() {
 		if err != nil {
 			cursorID, _ := msg.Op.CursorID()
+			command, collection := msg.Op.CommandAndCollection()
 			m.log.Error(
 				"Round trip error",
 				zap.Error(err),
 				zap.Int64("cursor_id", cursorID),
 				zap.Int32("op_code", int32(msg.Op.OpCode())),
 				zap.String("address", addr.String()),
+				zap.String("command", string(command)),
+				zap.String("collection", collection),
 			)
 		}
 	}()

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -192,7 +192,10 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 	}
 
 	addr = conn.Address()
-	tags = append(tags, fmt.Sprintf("address:%s", conn.Address().String()))
+	tags = append(
+		tags,
+		fmt.Sprintf("address:%s", conn.Address().String()),
+	)
 
 	defer func() {
 		err := conn.Close()

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -207,12 +207,13 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 		return nil, errors.New("server ErrorProcessor type assertion failed")
 	}
 
-	wm, err := m.roundTrip(conn, msg.Wm, msg.Op.Unacknowledged(), tags)
+	unacknowledged := msg.Op.Unacknowledged()
+	wm, err := m.roundTrip(conn, msg.Wm, unacknowledged, tags)
 	if err != nil {
 		m.processError(err, ep, addr, conn)
 		return nil, err
 	}
-	if msg.Op.Unacknowledged() {
+	if unacknowledged {
 		return &Message{}, nil
 	}
 

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -57,7 +57,7 @@ func TestRoundTrip(t *testing.T) {
 
 	msg := insertOpMsg(t)
 
-	res, err := m.RoundTrip(msg)
+	res, err := m.RoundTrip(msg, []string{})
 	assert.Nil(t, err)
 
 	single := mongo.ExtractSingleOpMsg(t, res)
@@ -90,7 +90,7 @@ func TestRoundTripProcessError(t *testing.T) {
 
 	msg := insertOpMsg(t)
 
-	res, err := m.RoundTrip(msg)
+	res, err := m.RoundTrip(msg, []string{})
 	assert.Nil(t, err)
 
 	single := mongo.ExtractSingleOpMsg(t, res)
@@ -103,7 +103,7 @@ func TestRoundTripProcessError(t *testing.T) {
 	// kill the proxy
 	p.Kill()
 
-	_, err = m.RoundTrip(msg)
+	_, err = m.RoundTrip(msg, []string{})
 	assert.Error(t, driver.Error{}, err)
 
 	assert.Equal(t, description.ServerKind(description.Unknown), m.Description().Servers[0].Kind, "Failed to update the server Kind to Unknown")

--- a/mongo/operations.go
+++ b/mongo/operations.go
@@ -646,7 +646,7 @@ func decodeUpdate(reqID int32, wm []byte) (*opUpdate, error) {
 		return nil, errors.New("malformed update message: selector document")
 	}
 
-	u.update, wm, ok = bsoncore.ReadDocument(wm)
+	u.update, _, ok = bsoncore.ReadDocument(wm)
 	if !ok {
 		return nil, errors.New("malformed update message: update document")
 	}
@@ -806,7 +806,7 @@ func decodeDelete(reqID int32, wm []byte) (*opDelete, error) {
 		return nil, errors.New("malformed delete message: missing OP_DELETE flags")
 	}
 
-	d.selector, wm, ok = bsoncore.ReadDocument(wm)
+	d.selector, _, ok = bsoncore.ReadDocument(wm)
 	if !ok {
 		return nil, errors.New("malformed delete message: selector document")
 	}
@@ -879,7 +879,7 @@ func decodeKillCursors(reqID int32, wm []byte) (*opKillCursors, error) {
 		return nil, errors.New("malformed kill_cursors message: missing number of cursor IDs")
 	}
 
-	k.cursorIDs, wm, ok = wiremessage.ReadKillCursorsCursorIDs(wm, numIDs)
+	k.cursorIDs, _, ok = wiremessage.ReadKillCursorsCursorIDs(wm, numIDs)
 	if !ok {
 		return nil, errors.New("malformed kill_cursors message: missing cursor IDs")
 	}

--- a/mongo/operations_test.go
+++ b/mongo/operations_test.go
@@ -18,7 +18,7 @@ func TestOpQuery(t *testing.T) {
 
 	op := opQuery{
 		flags:                wiremessage.AwaitData,
-		collName:             "trainers",
+		fullCollectionName:   "trainers",
 		numberToSkip:         5,
 		numberToReturn:       7,
 		query:                doc1,
@@ -31,7 +31,7 @@ func TestOpQuery(t *testing.T) {
 
 	msg := dec.(*opQuery)
 	assert.Equal(t, wiremessage.AwaitData, msg.flags)
-	assert.Equal(t, "trainers", msg.collName)
+	assert.Equal(t, "trainers", msg.fullCollectionName)
 	assert.Equal(t, int32(5), msg.numberToSkip)
 	assert.Equal(t, int32(7), msg.numberToReturn)
 	assert.Equal(t, doc1, []byte(msg.query))
@@ -53,8 +53,8 @@ func TestOpQueryIsIsMaster(t *testing.T) {
 	assert.Nil(t, err)
 
 	op := opQuery{
-		collName: "admin.$cmd",
-		query:    doc,
+		fullCollectionName: "admin.$cmd",
+		query:              doc,
 	}
 	assert.True(t, op.IsIsMaster())
 }

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -105,10 +105,7 @@ func (c *connection) handleMessage() (err error) {
 	}
 
 	if unacknowledged {
-		c.log.Debug(
-			"Unacknowledged request",
-			zap.Int32("op_code", int32(res.Op.OpCode())),
-		)
+		c.log.Debug("Unacknowledged request")
 		return
 	}
 

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -93,6 +93,11 @@ func (c *connection) handleMessage() (err error) {
 		return
 	}
 
+	if ce := c.log.Check(zap.DebugLevel, "Request"); ce != nil {
+		command, collection := op.CommandAndCollection()
+		ce.Write(zap.Int32("op_code", int32(op.OpCode())), zap.Int("request_size", len(wm)), zap.String("command", string(command)), zap.String("collection", collection))
+	}
+
 	isMaster = op.IsIsMaster()
 	req = &mongo.Message{
 		Wm: wm,

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"go.mongodb.org/mongo-driver/x/mongo/driver/wiremessage"
 	"go.uber.org/zap"
 
 	"github.com/coinbase/mongobetween/mongo"
@@ -59,28 +58,11 @@ func (c *connection) processMessages() {
 }
 
 func (c *connection) handleMessage() (err error) {
-	isMaster := false
-	var req, res *mongo.Message
+	var tags []string
 
 	defer func(start time.Time) {
-		var reqOpCode, resOpCode wiremessage.OpCode
-		collection := ""
-		command := mongo.Unknown
-		if req != nil {
-			command, collection = req.Op.CommandAndCollection()
-			reqOpCode = req.Op.OpCode()
-		}
-		if res != nil {
-			resOpCode = res.Op.OpCode()
-		}
-		_ = c.statsd.Timing("handle_message", time.Since(start), []string{
-			fmt.Sprintf("success:%v", err == nil),
-			fmt.Sprintf("is_master:%v", isMaster),
-			fmt.Sprintf("request_op_code:%v", reqOpCode),
-			fmt.Sprintf("response_op_code:%v", resOpCode),
-			fmt.Sprintf("command:%s", string(command)),
-			fmt.Sprintf("collection:%s", collection),
-		}, 1)
+		tags := append(tags, fmt.Sprintf("success:%v", err == nil))
+		_ = c.statsd.Timing("handle_message", time.Since(start), tags, 1)
 	}(time.Now())
 
 	var wm []byte
@@ -93,22 +75,40 @@ func (c *connection) handleMessage() (err error) {
 		return
 	}
 
-	if ce := c.log.Check(zap.DebugLevel, "Request"); ce != nil {
-		command, collection := op.CommandAndCollection()
-		ce.Write(zap.Int32("op_code", int32(op.OpCode())), zap.Int("request_size", len(wm)), zap.String("command", string(command)), zap.String("collection", collection))
-	}
+	isMaster := op.IsIsMaster()
+	command, collection := op.CommandAndCollection()
+	unacknowledged := op.Unacknowledged()
+	tags = append(
+		tags,
+		fmt.Sprintf("request_op_code:%v", op.OpCode()),
+		fmt.Sprintf("is_master:%v", isMaster),
+		fmt.Sprintf("command:%s", string(command)),
+		fmt.Sprintf("collection:%s", collection),
+		fmt.Sprintf("unacknowledged:%v", unacknowledged),
+	)
+	c.log.Debug(
+		"Request",
+		zap.Int32("op_code", int32(op.OpCode())),
+		zap.Bool("is_master", isMaster),
+		zap.String("command", string(command)),
+		zap.String("collection", collection),
+		zap.Int("request_size", len(wm)),
+	)
 
-	isMaster = op.IsIsMaster()
-	req = &mongo.Message{
+	req := &mongo.Message{
 		Wm: wm,
 		Op: op,
 	}
-
-	if res, err = c.roundTrip(req, isMaster); err != nil {
+	var res *mongo.Message
+	if res, err = c.roundTrip(req, isMaster, tags); err != nil {
 		return
 	}
-	if req.Op.Unacknowledged() {
-		c.log.Debug("Unacknowledged request", zap.Int32("op_code", int32(res.Op.OpCode())))
+
+	if unacknowledged {
+		c.log.Debug(
+			"Unacknowledged request",
+			zap.Int32("op_code", int32(res.Op.OpCode())),
+		)
 		return
 	}
 
@@ -116,7 +116,11 @@ func (c *connection) handleMessage() (err error) {
 		return
 	}
 
-	c.log.Debug("Response", zap.Int32("op_code", int32(res.Op.OpCode())), zap.Int("response_size", len(res.Wm)))
+	c.log.Debug(
+		"Response",
+		zap.Int32("op_code", int32(res.Op.OpCode())),
+		zap.Int("response_size", len(res.Wm)),
+	)
 	return
 }
 
@@ -145,13 +149,11 @@ func (c *connection) readWireMessage() ([]byte, error) {
 	return buffer, nil
 }
 
-func (c *connection) roundTrip(msg *mongo.Message, isMaster bool) (*mongo.Message, error) {
+func (c *connection) roundTrip(msg *mongo.Message, isMaster bool, tags []string) (*mongo.Message, error) {
 	if isMaster {
 		requestID := msg.Op.RequestID()
 		c.log.Debug("Non-proxied ismaster response", zap.Int32("request_id", requestID))
 		return mongo.IsMasterResponse(requestID, c.client.Description().Kind)
 	}
-
-	c.log.Debug("Proxying request to upstream server", zap.Int("request_size", len(msg.Wm)))
-	return c.client.RoundTrip(msg)
+	return c.client.RoundTrip(msg, tags)
 }

--- a/proxy/connection.go
+++ b/proxy/connection.go
@@ -109,6 +109,11 @@ func (c *connection) handleMessage() (err error) {
 		return
 	}
 
+	tags = append(
+		tags,
+		fmt.Sprintf("response_op_code:%v", res.Op.OpCode()),
+	)
+
 	if _, err = c.conn.Write(res.Wm); err != nil {
 		return
 	}

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -111,7 +111,7 @@ func TestProxyUnacknowledgedWrites(t *testing.T) {
 	unackCollection, err := setupCollection.Clone(options.Collection().SetWriteConcern(wc))
 	assert.Nil(t, err)
 
-	// Setup by deleteing all documents.
+	// Setup by deleting all documents.
 	_, err = setupCollection.DeleteMany(ctx, bson.D{})
 	assert.Nil(t, err)
 


### PR DESCRIPTION
This PR ultimately adds more observability tags to the round trip metrics like `mongobetween.handle_message` and `mongobetween.round_trip`. New tags include:
 - `command`: the Mongo command being run, one of `[abortTransaction, aggregate, commandTransaction, count, createIndexes, delete, distinct, drop, dropDatabase, dropIndexes, endSessions, find, findAndModify, getMore, insert, isMaster, listCollections, listIndexes, listDatabases, mapReduce, update]`
 - `collection`: the collection the command is running on, if any (not applicable to non-collection commands, e.g. `dropDatabase`)

Previously mongobetween was missing parsers for operations like `OP_UPDATE`, `OP_INSERT`, `OP_KILL_CURSORS`, and `OP_DELETE`. These have been implemented in order to capture them in metrics.