### PR TITLE
Updated IsIsMasterDoc function to work with drivers that send IsMaste…

### DIFF
--- a/mongo/command.go
+++ b/mongo/command.go
@@ -73,7 +73,17 @@ func CommandAndCollection(msg bsoncore.Document) (Command, string) {
 }
 
 func IsIsMasterDoc(doc bsoncore.Document) bool {
-	isMaster, _ := doc.Lookup(string(IsMaster)).Int32OK()
-	ismaster, _ := doc.Lookup(string(Ismaster)).Int32OK()
-	return ismaster+isMaster > 0
+	isMaster := doc.Lookup(string(IsMaster))
+	ismaster := doc.Lookup(string(Ismaster))
+	return IsIsMasterValueTruthy(isMaster) || IsIsMasterValueTruthy(ismaster)
+}
+
+func IsIsMasterValueTruthy(val bsoncore.Value) bool {
+	if intValue, isInt := val.Int32OK(); intValue > 0 {
+		return true;
+	} else if !isInt {
+		boolValue, isBool := val.BooleanOK()
+		return boolValue && isBool
+	}
+	return false;
 }


### PR DESCRIPTION
### Issue
This fixes the following issue: https://github.com/coinbase/mongobetween/issues/30

### Summary
The node.js driver, and potentially other drivers, make a handshake with the `isMaster` document formatted a little bit differently than what the current code expects. The `ismaster`|`isMaster` value is a boolean, instead of a number. This is causing the isMaster command to breach the proxy and reach the server, and when sent with client metadata, causes the server to respond with the error:

> MongoServerSelectionError: The client metadata document may only be sent in the first isMaster

Here are examples of different drivers and how their document in this [function](https://github.com/coinbase/mongobetween/blob/master/mongo/command.go#L75) appear:

**node.js**
```json
{"ismaster": true,"helloOk": true,"client": {"driver": {"name": "nodejs","version": "4.2.0"},"os": {"type": "Darwin","name": "darwin","architecture": "x64","version": "20.6.0"},"platform": "Node.js v14.15.4, LE (unified)\|Node.js v14.15.4, LE (unified)"},"compression": ["none"],"loadBalanced": false}
```
**MongoDB Shell**
```json
{"isMaster": {"$numberInt":"1"},"client": {"application": {"name": "MongoDB Shell"},"driver": {"name": "MongoDB Internal Client","version": "4.4.0"},"os": {"type": "Darwin","name": "Mac OS X","architecture": "x86_64","version": "20.6.0"}}}
```

**PyMongo**
```json
{"ismaster": {"$numberInt":"1"},"helloOk": true,"client": {"driver": {"name": "PyMongo","version": "4.0"},"os": {"type": "Darwin","name": "Darwin","architecture": "x86_64","version": "10.16"},"platform": "CPython 3.9.4.final.0"}}
```


### Changes
This change will make drivers that pass in boolean values for `isMaster` to be successfully intercepted.
