### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.17 as build
+WORKDIR /go/src
+COPY . .
+RUN CGO_ENABLED=0 make
+
+
+FROM scratch
+COPY --from=build /etc/ssl/certs/ca-certificates.crt \
+     /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /go/src/bin/mongobetween /mongobetween
+ENTRYPOINT ["/mongobetween"]


### PR DESCRIPTION
Hey there :wave:

Thank you for this useful tool.

This PR proposes a simple Dockerfile to build a docker image containing only the mongobetween binary (FROM scratch).
This should help usage in k8s sidecars.
