### PR TITLE
Transaction and cursor server pinning support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ This will disable writes to the proxy served from address `:12345`, and redirect
 ### TODO
 
 Current known missing features:
- - [ ] Transaction server pinning
- - [ ] Different cursors on separate servers with the same cursor ID value
+ - [X] Transaction server pinning
+ - [X] Different cursors on separate servers with the same cursor ID value
+
 
 ### Statsd
 `mongobetween` supports reporting health metrics to a local statsd sidecar, using the [Datadog Go library](github.com/DataDog/datadog-go). By default it reports to `localhost:8125`. The following metrics are reported:
@@ -89,6 +90,7 @@ Current known missing features:
  - `mongobetween.connection_opened` (Counter) - connection opened with the application
  - `mongobetween.connection_closed` (Counter) - connection closed with the application
  - `mongobetween.cursors` (Gauge) - number of open cursors being tracked (for cursor -> server mapping)
+ - `mongobetween.transactions` (Gauge) - number of transactions being tracked (for client sessions -> server mapping)****
  - `mongobetween.server_selection` (Timing) - Go driver server selection timing
  - `mongobetween.checkout_connection` (Timing) - Go driver connection checkout timing
  - `mongobetween.pool.checked_out_connections` (Gauge) - number of connections checked out from the Go driver connection pool

--- a/mongo/command.go
+++ b/mongo/command.go
@@ -60,6 +60,9 @@ func CommandAndCollection(msg bsoncore.Document) (Command, string) {
 	for _, s := range int64Commands {
 		value := msg.Lookup(string(s))
 		if value.Data != nil {
+			if coll, ok := msg.Lookup("collection").StringValueOK(); ok {
+				return s, coll
+			}
 			return s, ""
 		}
 	}

--- a/mongo/cursor_cache.go
+++ b/mongo/cursor_cache.go
@@ -13,7 +13,7 @@ import (
 const maxCursors = 1024 * 1024
 
 // one day expiry
-const expiry = 24 * time.Hour
+const cursorExpiry = 24 * time.Hour
 
 type cursorCache struct {
 	c *lruttl.Cache
@@ -21,7 +21,7 @@ type cursorCache struct {
 
 func newCursorCache() *cursorCache {
 	return &cursorCache{
-		c: lruttl.New(maxCursors, expiry),
+		c: lruttl.New(maxCursors, cursorExpiry),
 	}
 }
 

--- a/mongo/cursor_cache.go
+++ b/mongo/cursor_cache.go
@@ -1,6 +1,7 @@
 package mongo
 
 import (
+	"fmt"
 	"time"
 
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
@@ -28,18 +29,23 @@ func (c *cursorCache) count() int {
 	return c.c.Len()
 }
 
-func (c *cursorCache) peek(cursorID int64) (server driver.Server, ok bool) {
-	v, ok := c.c.Peek(cursorID)
+func (c *cursorCache) peek(cursorID int64, collection string) (server driver.Server, ok bool) {
+
+	v, ok := c.c.Peek(buildKey(cursorID, collection))
 	if !ok {
 		return
 	}
 	return v.(driver.Server), true
 }
 
-func (c *cursorCache) add(cursorID int64, server driver.Server) {
-	c.c.Add(cursorID, server)
+func (c *cursorCache) add(cursorID int64, collection string, server driver.Server) {
+	c.c.Add(buildKey(cursorID, collection), server)
 }
 
-func (c *cursorCache) remove(cursorID int64) {
-	c.c.Remove(cursorID)
+func (c *cursorCache) remove(cursorID int64, collection string) {
+	c.c.Remove(buildKey(cursorID, collection))
+}
+
+func buildKey(cursorID int64, collection string) string {
+	return fmt.Sprintf("%d-%s", cursorID, collection)
 }

--- a/mongo/cursor_cache_test.go
+++ b/mongo/cursor_cache_test.go
@@ -22,58 +22,62 @@ func (m *mockServer) MinRTT() time.Duration {
 
 func TestCount(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, &mockServer{})
-	cc.add(12, &mockServer{})
-	cc.add(14, &mockServer{})
+	cc.add(10, "db.coll", &mockServer{})
+	cc.add(12, "db.coll", &mockServer{})
+	cc.add(14, "db.coll", &mockServer{})
 	assert.Equal(t, 3, cc.count())
 
-	cc.add(10, &mockServer{10})
+	cc.add(10, "db.coll", &mockServer{10})
 	assert.Equal(t, 3, cc.count())
+
+	cc.add(10, "db.coll2", &mockServer{10})
+	assert.Equal(t, 4, cc.count())
+
 }
 
 func TestPeek(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, &mockServer{4})
-	cc.add(12, &mockServer{5})
-	cc.add(14, &mockServer{6})
+	cc.add(10, "db.coll", &mockServer{4})
+	cc.add(12, "db.coll", &mockServer{5})
+	cc.add(14, "db.coll", &mockServer{6})
 
-	s, ok := cc.peek(12)
+	s, ok := cc.peek(12, "db.coll")
 	assert.True(t, ok)
 	assert.Equal(t, s.(*mockServer).i, 5)
 
-	_, ok = cc.peek(13)
+	_, ok = cc.peek(13, "db.coll")
 	assert.False(t, ok)
 }
 
 func TestAdd(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, &mockServer{4})
-	cc.add(12, &mockServer{5})
-	cc.add(14, &mockServer{6})
+	cc.add(10, "db.coll", &mockServer{4})
+	cc.add(12, "db.coll", &mockServer{5})
+	cc.add(14, "db.coll", &mockServer{6})
 
-	_, ok := cc.peek(13)
+	_, ok := cc.peek(13, "db.coll")
 	assert.False(t, ok)
 
-	cc.add(13, &mockServer{7})
-	_, ok = cc.peek(13)
+	cc.add(13, "db.coll", &mockServer{7})
+	_, ok = cc.peek(13, "db.coll")
 	assert.True(t, ok)
 }
 
 func TestRemove(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, &mockServer{4})
-	cc.add(12, &mockServer{5})
-	cc.add(14, &mockServer{6})
+	cc.add(10, "db.coll", &mockServer{4})
+	cc.add(12, "db.coll", &mockServer{5})
+	cc.add(14, "db.coll", &mockServer{6})
 	assert.Equal(t, 3, cc.count())
 
-	_, ok := cc.peek(12)
+	_, ok := cc.peek(12, "db.coll")
 	assert.True(t, ok)
 
-	cc.remove(12)
-	_, ok = cc.peek(12)
+	cc.remove(12, "db.coll")
+	_, ok = cc.peek(12, "db.coll")
 	assert.False(t, ok)
 	assert.Equal(t, 2, cc.count())
 
-	cc.remove(13)
+	cc.remove(13, "db.coll")
 	assert.Equal(t, 2, cc.count())
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -89,7 +89,7 @@ func Connect(log *zap.Logger, sd *statsd.Client, opts *options.ClientOptions, pi
 		roundTripCtx:    rtCtx,
 		roundTripCancel: rtCancel,
 	}
-	go m.cursorMonitor()
+	go m.cacheMonitor()
 
 	return &m, nil
 }
@@ -126,9 +126,14 @@ func (m *Mongo) Description() description.Topology {
 	return m.topology.Description()
 }
 
-func (m *Mongo) cursorMonitor() {
+func (m *Mongo) cacheGauge(name string, count float64) {
+	_ = m.statsd.Gauge(name, count, []string{}, 1)
+}
+
+func (m *Mongo) cacheMonitor() {
 	for {
-		_ = m.statsd.Gauge("cursors", float64(m.cursors.count()), []string{}, 1)
+		m.cacheGauge("cursors", float64(m.cursors.count()))
+		m.cacheGauge("transactions", float64(m.cursors.count()))
 		time.Sleep(1 * time.Second)
 	}
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -188,7 +188,7 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 	// Transaction is pinned to a server by the issued lsid
 	requestCursorID, _ := msg.Op.CursorID()
 	requestCommand, collection := msg.Op.CommandAndCollection()
-	transactionDetails, _ := msg.Op.TransactionDetails()
+	transactionDetails := msg.Op.TransactionDetails()
 	server, err := m.selectServer(requestCursorID, collection, transactionDetails)
 	if err != nil {
 		return nil, err

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -133,7 +133,7 @@ func (m *Mongo) cacheGauge(name string, count float64) {
 func (m *Mongo) cacheMonitor() {
 	for {
 		m.cacheGauge("cursors", float64(m.cursors.count()))
-		m.cacheGauge("transactions", float64(m.cursors.count()))
+		m.cacheGauge("transactions", float64(m.transactions.count()))
 		time.Sleep(1 * time.Second)
 	}
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -250,11 +250,11 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 
 	if transactionDetails != nil {
 		if transactionDetails.IsStartTransaction {
-			m.transactions.add(transactionDetails.LsId, server)
+			m.transactions.add(transactionDetails.LsID, server)
 		} else {
 			if requestCommand == AbortTransaction || requestCommand == CommitTransaction {
 				m.log.Debug("Removing transaction from the cache", zap.String("reqCommand", string(requestCommand)))
-				m.transactions.remove(transactionDetails.LsId)
+				m.transactions.remove(transactionDetails.LsID)
 			}
 		}
 	}
@@ -272,7 +272,7 @@ func (m *Mongo) selectServer(requestCursorID int64, collection string, transDeta
 
 	// Check for a pinned server based on current transaction lsid first
 	if transDetails != nil {
-		if server, ok := m.transactions.peek(transDetails.LsId); ok {
+		if server, ok := m.transactions.peek(transDetails.LsID); ok {
 			m.log.Debug("found cached transaction", zap.String("lsid", fmt.Sprintf("%+v", transDetails)))
 			return server, nil
 		}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -253,7 +253,7 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 			m.transactions.add(transactionDetails.LsId, server)
 		} else {
 			if requestCommand == AbortTransaction || requestCommand == CommitTransaction {
-				m.log.Info("Removing transaction from the cache", zap.String("reqCommand", string(requestCommand)))
+				m.log.Debug("Removing transaction from the cache", zap.String("reqCommand", string(requestCommand)))
 				m.transactions.remove(transactionDetails.LsId)
 			}
 		}
@@ -273,7 +273,7 @@ func (m *Mongo) selectServer(requestCursorID int64, collection string, transDeta
 	// Check for a pinned server based on current transaction lsid first
 	if transDetails != nil {
 		if server, ok := m.transactions.peek(transDetails.LsId); ok {
-			m.log.Info("found cached transaction", zap.String("lsid", fmt.Sprintf("%+v", transDetails)))
+			m.log.Debug("found cached transaction", zap.String("lsid", fmt.Sprintf("%+v", transDetails)))
 			return server, nil
 		}
 	}
@@ -282,7 +282,7 @@ func (m *Mongo) selectServer(requestCursorID int64, collection string, transDeta
 	if requestCursorID != 0 {
 		server, ok := m.cursors.peek(requestCursorID, collection)
 		if ok {
-			m.log.Info("Cached cursorID has been found", zap.Int64("cursor", requestCursorID), zap.String("collection", collection))
+			m.log.Debug("Cached cursorID has been found", zap.Int64("cursor", requestCursorID), zap.String("collection", collection))
 			return server, nil
 		}
 	}

--- a/mongo/operations.go
+++ b/mongo/operations.go
@@ -448,25 +448,26 @@ func (m *opMsg) CommandAndCollection() (Command, string) {
 func (m *opMsg) TransactionDetails() (*TransactionDetails, bool) {
 
 	for _, section := range m.sections {
+
 		if single, ok := section.(*opMsgSectionSingle); ok {
-			var ok bool
-			_, lsid, ok := single.msg.Lookup("lsid", "id").BinaryOK()
+			_, lsId, ok := single.msg.Lookup("lsid", "id").BinaryOK()
 			if !ok {
 				continue
 			}
+
 			txnNumber, ok := single.msg.Lookup("txnNumber").Int64OK()
 			if !ok {
 				continue
 			}
+
 			_, ok = single.msg.Lookup("autocommit").BooleanOK()
 			if !ok {
 				continue
 			}
 
 			startTransaction, ok := single.msg.Lookup("startTransaction").BooleanOK()
-
 			return &TransactionDetails{
-				LsId:               lsid,
+				LsId:               lsId,
 				TxnNumber:          txnNumber,
 				IsStartTransaction: ok && startTransaction,
 			}, true

--- a/mongo/operations.go
+++ b/mongo/operations.go
@@ -32,7 +32,7 @@ type Operation interface {
 	Error() error
 	Unacknowledged() bool
 	CommandAndCollection() (Command, string)
-	TransactionDetails() (*TransactionDetails, bool)
+	TransactionDetails() *TransactionDetails
 }
 
 // see https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/x/mongo/driver/operation.go#L1361-L1426
@@ -81,8 +81,8 @@ type opUnknown struct {
 	wm     []byte
 }
 
-func (o *opUnknown) TransactionDetails() (*TransactionDetails, bool) {
-	return nil, false
+func (o *opUnknown) TransactionDetails() *TransactionDetails {
+	return nil
 }
 
 func (o *opUnknown) OpCode() wiremessage.OpCode {
@@ -132,8 +132,8 @@ type opQuery struct {
 	returnFieldsSelector bsoncore.Document
 }
 
-func (q *opQuery) TransactionDetails() (*TransactionDetails, bool) {
-	return nil, false
+func (q *opQuery) TransactionDetails() *TransactionDetails {
+	return nil
 }
 
 // see https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/x/mongo/driver/topology/server_test.go#L968-L1003
@@ -445,7 +445,7 @@ func (m *opMsg) CommandAndCollection() (Command, string) {
 // opMsg is available from wire protocol 3.6
 // deprecated operations such OP_UPDATE OP_INSERT are not supposed to support transaction statements.
 // When constructing any other command within a transaction, drivers MUST add the lsid, txnNumber, and autocommit fields.
-func (m *opMsg) TransactionDetails() (*TransactionDetails, bool) {
+func (m *opMsg) TransactionDetails() *TransactionDetails {
 
 	for _, section := range m.sections {
 
@@ -470,11 +470,11 @@ func (m *opMsg) TransactionDetails() (*TransactionDetails, bool) {
 				LsId:               lsId,
 				TxnNumber:          txnNumber,
 				IsStartTransaction: ok && startTransaction,
-			}, true
+			}
 		}
 	}
 
-	return nil, false
+	return nil
 }
 
 func (m *opMsg) String() string {
@@ -495,8 +495,8 @@ type opReply struct {
 	documents    []bsoncore.Document
 }
 
-func (r *opReply) TransactionDetails() (*TransactionDetails, bool) {
-	return nil, false
+func (r *opReply) TransactionDetails() *TransactionDetails {
+	return nil
 }
 
 // see https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/x/mongo/driver/operation.go#L1297-L1358
@@ -596,8 +596,8 @@ type opGetMore struct {
 	cursorID           int64
 }
 
-func (g *opGetMore) TransactionDetails() (*TransactionDetails, bool) {
-	return nil, false
+func (g *opGetMore) TransactionDetails() *TransactionDetails {
+	return nil
 }
 
 // see https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/x/mongo/driver/operation.go#L1297-L1358
@@ -685,8 +685,8 @@ type opUpdate struct {
 	update             bsoncore.Document
 }
 
-func (u *opUpdate) TransactionDetails() (*TransactionDetails, bool) {
-	return nil, false
+func (u *opUpdate) TransactionDetails() *TransactionDetails {
+	return nil
 }
 
 func decodeUpdate(reqID int32, wm []byte) (*opUpdate, error) {
@@ -769,8 +769,8 @@ type opInsert struct {
 	documents          []bsoncore.Document
 }
 
-func (i *opInsert) TransactionDetails() (*TransactionDetails, bool) {
-	return nil, false
+func (i *opInsert) TransactionDetails() *TransactionDetails {
+	return nil
 }
 
 func decodeInsert(reqID int32, wm []byte) (*opInsert, error) {
@@ -853,8 +853,8 @@ type opDelete struct {
 	selector           bsoncore.Document
 }
 
-func (d *opDelete) TransactionDetails() (*TransactionDetails, bool) {
-	return nil, false
+func (d *opDelete) TransactionDetails() *TransactionDetails {
+	return nil
 }
 
 func decodeDelete(reqID int32, wm []byte) (*opDelete, error) {
@@ -934,8 +934,8 @@ type opKillCursors struct {
 	cursorIDs []int64
 }
 
-func (k *opKillCursors) TransactionDetails() (*TransactionDetails, bool) {
-	return nil, false
+func (k *opKillCursors) TransactionDetails() *TransactionDetails {
+	return nil
 }
 
 func decodeKillCursors(reqID int32, wm []byte) (*opKillCursors, error) {

--- a/mongo/operations.go
+++ b/mongo/operations.go
@@ -17,7 +17,7 @@ type Message struct {
 }
 
 type TransactionDetails struct {
-	LsId               []byte
+	LsID               []byte
 	TxnNumber          int64
 	IsStartTransaction bool
 }
@@ -450,7 +450,7 @@ func (m *opMsg) TransactionDetails() *TransactionDetails {
 	for _, section := range m.sections {
 
 		if single, ok := section.(*opMsgSectionSingle); ok {
-			_, lsId, ok := single.msg.Lookup("lsid", "id").BinaryOK()
+			_, lsID, ok := single.msg.Lookup("lsid", "id").BinaryOK()
 			if !ok {
 				continue
 			}
@@ -467,7 +467,7 @@ func (m *opMsg) TransactionDetails() *TransactionDetails {
 
 			startTransaction, ok := single.msg.Lookup("startTransaction").BooleanOK()
 			return &TransactionDetails{
-				LsId:               lsId,
+				LsID:               lsID,
 				TxnNumber:          txnNumber,
 				IsStartTransaction: ok && startTransaction,
 			}

--- a/mongo/operations_test.go
+++ b/mongo/operations_test.go
@@ -134,6 +134,7 @@ func TestOpMessageTransactionDetails(t *testing.T) {
 			{Key: "txnNumber", Value: int64(1)},
 			{Key: "autocommit", Value: true},
 		})
+	assert.NoError(t, err)
 	op := opMsg{
 		flags: wiremessage.MoreToCome,
 		sections: []opMsgSection{

--- a/mongo/operations_test.go
+++ b/mongo/operations_test.go
@@ -145,8 +145,8 @@ func TestOpMessageTransactionDetails(t *testing.T) {
 	dec, err := Decode(wm)
 	assert.Nil(t, err)
 
-	details, ok := dec.TransactionDetails()
-	assert.True(t, ok)
+	details := dec.TransactionDetails()
+	assert.NotNil(t, details)
 	assert.False(t, details.IsStartTransaction)
 	assert.Equal(t, int64(1), details.TxnNumber)
 }

--- a/mongo/transaction_cache.go
+++ b/mongo/transaction_cache.go
@@ -25,18 +25,18 @@ func (t *transactionCache) count() int {
 	return t.c.Len()
 }
 
-func (t *transactionCache) peek(lsId []byte) (server driver.Server, ok bool) {
-	v, ok := t.c.Peek(b64.StdEncoding.EncodeToString(lsId))
+func (t *transactionCache) peek(lsID []byte) (server driver.Server, ok bool) {
+	v, ok := t.c.Peek(b64.StdEncoding.EncodeToString(lsID))
 	if !ok {
 		return
 	}
 	return v.(driver.Server), true
 }
 
-func (t *transactionCache) add(lsId []byte, server driver.Server) {
-	t.c.Add(b64.StdEncoding.EncodeToString(lsId), server)
+func (t *transactionCache) add(lsID []byte, server driver.Server) {
+	t.c.Add(b64.StdEncoding.EncodeToString(lsID), server)
 }
 
-func (t *transactionCache) remove(lsId []byte) {
-	t.c.Remove(b64.StdEncoding.EncodeToString(lsId))
+func (t *transactionCache) remove(lsID []byte) {
+	t.c.Remove(b64.StdEncoding.EncodeToString(lsID))
 }

--- a/mongo/transaction_cache.go
+++ b/mongo/transaction_cache.go
@@ -1,0 +1,42 @@
+package mongo
+
+import (
+	b64 "encoding/base64"
+	"github.com/coinbase/mongobetween/lruttl"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"time"
+)
+
+// on a 64-bit machine, 1 million cursors uses around 480mb of memory
+const maxTransactions = 1024 * 1024
+
+// 120 seconds default
+const transactionExpiry = 120 * time.Second
+
+type transactionCache struct {
+	c *lruttl.Cache
+}
+
+func newTransactionCache() *transactionCache {
+	return &transactionCache{c: lruttl.New(maxTransactions, transactionExpiry)}
+}
+
+func (t *transactionCache) count() int {
+	return t.c.Len()
+}
+
+func (t *transactionCache) peek(lsId []byte) (server driver.Server, ok bool) {
+	v, ok := t.c.Peek(b64.StdEncoding.EncodeToString(lsId))
+	if !ok {
+		return
+	}
+	return v.(driver.Server), true
+}
+
+func (t *transactionCache) add(lsId []byte, server driver.Server) {
+	t.c.Add(b64.StdEncoding.EncodeToString(lsId), server)
+}
+
+func (t *transactionCache) remove(lsId []byte) {
+	t.c.Remove(b64.StdEncoding.EncodeToString(lsId))
+}

--- a/mongo/transaction_cache_test.go
+++ b/mongo/transaction_cache_test.go
@@ -5,10 +5,15 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"testing"
+	"time"
 )
 
 type transactionMockServer struct {
 	i int
+}
+
+func (m *transactionMockServer) MinRTT() time.Duration {
+	return time.Duration(0)
 }
 
 func (m *transactionMockServer) Connection(context.Context) (driver.Connection, error) {

--- a/mongo/transaction_cache_test.go
+++ b/mongo/transaction_cache_test.go
@@ -1,0 +1,78 @@
+package mongo
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"testing"
+)
+
+type transactionMockServer struct {
+	i int
+}
+
+func (m *transactionMockServer) Connection(context.Context) (driver.Connection, error) {
+	return nil, nil
+}
+
+func TestTransactionCacheCount(t *testing.T) {
+	tc := newTransactionCache()
+	tc.add([]byte{0x1}, &transactionMockServer{})
+	tc.add([]byte{0x2}, &transactionMockServer{})
+	tc.add([]byte{0x3}, &transactionMockServer{})
+	assert.Equal(t, 3, tc.count())
+
+	tc.add([]byte{0x1}, &transactionMockServer{10})
+	assert.Equal(t, 3, tc.count())
+
+	tc.add([]byte{0x10}, &transactionMockServer{10})
+	assert.Equal(t, 4, tc.count())
+
+}
+
+func TestTransactionCachePeek(t *testing.T) {
+	tc := newTransactionCache()
+	tc.add([]byte{0x10}, &transactionMockServer{4})
+	tc.add([]byte{0x12}, &transactionMockServer{5})
+	tc.add([]byte{0x14}, &transactionMockServer{6})
+
+	s, ok := tc.peek([]byte{0x12})
+	assert.True(t, ok)
+	assert.Equal(t, s.(*transactionMockServer).i, 5)
+
+	_, ok = tc.peek([]byte{0x13})
+	assert.False(t, ok)
+}
+
+func TestTransactionCacheAdd(t *testing.T) {
+	tc := newTransactionCache()
+	tc.add([]byte{0x10}, &transactionMockServer{4})
+	tc.add([]byte{0x12}, &transactionMockServer{5})
+	tc.add([]byte{0x14}, &transactionMockServer{6})
+
+	_, ok := tc.peek([]byte{0x13})
+	assert.False(t, ok)
+
+	tc.add([]byte{0x13}, &transactionMockServer{7})
+	_, ok = tc.peek([]byte{0x13})
+	assert.True(t, ok)
+}
+
+func TestTransactionTestRemove(t *testing.T) {
+	tc := newTransactionCache()
+	tc.add([]byte{0x10}, &transactionMockServer{4})
+	tc.add([]byte{0x12}, &transactionMockServer{5})
+	tc.add([]byte{0x14}, &transactionMockServer{6})
+	assert.Equal(t, 3, tc.count())
+
+	_, ok := tc.peek([]byte{0x12})
+	assert.True(t, ok)
+
+	tc.remove([]byte{0x12})
+	_, ok = tc.peek([]byte{0x12})
+	assert.False(t, ok)
+	assert.Equal(t, 2, tc.count())
+
+	tc.remove([]byte{0x13})
+	assert.Equal(t, 2, tc.count())
+}


### PR DESCRIPTION
Hey there!

This PR aims to implement 2 known missing features:

* Transaction server pinning
* Different cursors on separate servers with the same cursor ID value


Cursors are pinned to a server selection by using `<cursorID>-<collection-name>` as unique identifier (could't find better identifier)

Transactions pinning use `lsid` and that should be random enough to guarantee uniqueness among different connections

 