### PR TITLE
Upgrade test mongo to 4.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: "3.7"
 
 services:
   mongo1:
-    image: "mongo:4.2"
+    image: "mongo:4.4"
     ports:
       - "27017:27017"
   mongo2:
-    image: "mongo:4.2"
+    image: "mongo:4.4"
     ports:
       - "27018:27017"
   mongo3:
-    image: "mongo:4.2"
+    image: "mongo:4.4"
     ports:
       - "27019:27017"


### PR DESCRIPTION
We could have a build system where we run mongobetween against multiple different versions of mongo, but I don't think that's worth it right now. Test suite passes locally with the latest version