### PR TITLE
Add support for dual reads in mongobetween

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/DataDog/datadog-go v3.7.1+incompatible
-	github.com/hashicorp/go-getter v1.5.9
+	github.com/hashicorp/go-getter v1.5.11
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9n
 github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-getter v1.5.9 h1:b7ahZW50iQiUek/at3CvZhPK1/jiV6CtKcsJiR6E4R0=
 github.com/hashicorp/go-getter v1.5.9/go.mod h1:BrrV/1clo8cCYu6mxvboYg+KutTiFnXjMEgDD8+i7ZI=
+github.com/hashicorp/go-getter v1.5.11 h1:wioTuNmaBU3IE9vdFtFMcmZWj0QzLc6DYaP6sNe5onY=
+github.com/hashicorp/go-getter v1.5.11/go.mod h1:9i48BP6wpWweI/0/+FBjqLrp9S8XtwUGjiu0QkWHEaY=
 github.com/hashicorp/go-safetemp v1.0.0 h1:2HR189eFNrjHQyENnQMMpCiBAsRxzbTMIgBhEyExpmo=
 github.com/hashicorp/go-safetemp v1.0.0/go.mod h1:oaerMy3BhqiTbVye6QuFhFtIceqFoDHxNAB65b+Rj1I=
 github.com/hashicorp/go-version v1.1.0 h1:bPIoEKD27tNdebFGGxxYwcL4nepeY4j1QP23PFRGzg0=

--- a/mongo/command.go
+++ b/mongo/command.go
@@ -45,6 +45,15 @@ func IsWrite(command Command) bool {
 	return false
 }
 
+// This feels super weak?
+func IsRead(command Command) bool {
+	switch command {
+	case Aggregate, Count, Find, GetMore, ListCollections, ListIndexes:
+		return true
+	}
+	return false
+}
+
 func CommandAndCollection(msg bsoncore.Document) (Command, string) {
 	for _, s := range collectionCommands {
 		if coll, ok := msg.Lookup(string(s)).StringValueOK(); ok {
@@ -83,10 +92,10 @@ func IsIsMasterDoc(doc bsoncore.Document) bool {
 
 func IsIsMasterValueTruthy(val bsoncore.Value) bool {
 	if intValue, isInt := val.Int32OK(); intValue > 0 {
-		return true;
+		return true
 	} else if !isInt {
 		boolValue, isBool := val.BooleanOK()
 		return boolValue && isBool
 	}
-	return false;
+	return false
 }

--- a/mongo/command.go
+++ b/mongo/command.go
@@ -45,7 +45,6 @@ func IsWrite(command Command) bool {
 	return false
 }
 
-// This feels super weak?
 func IsRead(command Command) bool {
 	switch command {
 	case Aggregate, Count, Find, GetMore, ListCollections, ListIndexes:

--- a/mongo/cursor_cache.go
+++ b/mongo/cursor_cache.go
@@ -2,6 +2,7 @@ package mongo
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
@@ -30,7 +31,6 @@ func (c *cursorCache) count() int {
 }
 
 func (c *cursorCache) peek(cursorID int64, collection string) (server driver.Server, ok bool) {
-
 	v, ok := c.c.Peek(buildKey(cursorID, collection))
 	if !ok {
 		return
@@ -43,6 +43,32 @@ func (c *cursorCache) add(cursorID int64, collection string, server driver.Serve
 }
 
 func (c *cursorCache) remove(cursorID int64, collection string) {
+	c.c.Remove(buildKey(cursorID, collection))
+}
+
+func (c *cursorCache) peekDualID(cursorID int64, collection string) (int64, bool) {
+	v, ok := c.c.Peek(buildKey(cursorID, collection))
+	if !ok {
+		return 0, ok
+	}
+
+	str, ok := v.(string)
+	if !ok {
+		return 0, ok
+	}
+
+	id, err := strconv.ParseInt(str, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return int64(id), true
+}
+
+func (c *cursorCache) addDualID(cursorID int64, collection string, dualCursorID int64) {
+	c.c.Add(buildKey(cursorID, collection), strconv.FormatInt(dualCursorID, 10))
+}
+
+func (c *cursorCache) removeDualID(cursorID int64, collection string) {
 	c.c.Remove(buildKey(cursorID, collection))
 }
 

--- a/mongo/cursor_cache.go
+++ b/mongo/cursor_cache.go
@@ -46,7 +46,7 @@ func (c *cursorCache) remove(cursorID int64, collection string) {
 	c.c.Remove(buildKey(cursorID, collection))
 }
 
-func (c *cursorCache) peekDualID(cursorID int64, collection string) (int64, bool) {
+func (c *cursorCache) peekDualCursorID(cursorID int64, collection string) (int64, bool) {
 	v, ok := c.c.Peek(buildKey(cursorID, collection))
 	if !ok {
 		return 0, ok
@@ -64,11 +64,11 @@ func (c *cursorCache) peekDualID(cursorID int64, collection string) (int64, bool
 	return int64(id), true
 }
 
-func (c *cursorCache) addDualID(cursorID int64, collection string, dualCursorID int64) {
+func (c *cursorCache) addDualCursorID(cursorID int64, collection string, dualCursorID int64) {
 	c.c.Add(buildKey(cursorID, collection), strconv.FormatInt(dualCursorID, 10))
 }
 
-func (c *cursorCache) removeDualID(cursorID int64, collection string) {
+func (c *cursorCache) removeDualCursorID(cursorID int64, collection string) {
 	c.c.Remove(buildKey(cursorID, collection))
 }
 

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -274,8 +274,8 @@ func (m *Mongo) RoundTripWithDualCursor(msg *Message, tags []string, originalCur
 	}
 
 	// Rewrite message with new cursor ID if doing a getMore
-	if msgGetMore, ok := (msg.Op).(*opMsg); ok {
-		encodedMsg := msgGetMore.EncodeWithCursorID(msg.Op.RequestID(), requestCursorID)
+	if opMsg, ok := (msg.Op).(*opMsg); ok {
+		encodedMsg := opMsg.EncodeWithCursorID(msg.Op.RequestID(), requestCursorID)
 		decodedMsg, err := Decode(encodedMsg)
 		if err == nil {
 			msg = &Message{

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -58,7 +58,7 @@ func TestRoundTrip(t *testing.T) {
 
 	msg := insertOpMsg(t)
 
-	res, err := m.RoundTrip(msg, []string{}, 0)
+	res, err := m.RoundTrip(msg, []string{})
 	assert.Nil(t, err)
 
 	single := mongo.ExtractSingleOpMsg(t, res)
@@ -99,7 +99,7 @@ func TestRoundTripProcessError(t *testing.T) {
 
 	msg := insertOpMsg(t)
 
-	res, err := m.RoundTrip(msg, []string{}, 0)
+	res, err := m.RoundTrip(msg, []string{})
 	assert.Nil(t, err)
 
 	single := mongo.ExtractSingleOpMsg(t, res)
@@ -112,7 +112,7 @@ func TestRoundTripProcessError(t *testing.T) {
 	// kill the proxy
 	p.Kill()
 
-	_, err = m.RoundTrip(msg, []string{}, 0)
+	_, err = m.RoundTrip(msg, []string{})
 	assert.Error(t, driver.Error{}, err)
 
 	assert.Equal(t, description.ServerKind(description.Unknown), m.Description().Servers[0].Kind, "Failed to update the server Kind to Unknown")

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -1,6 +1,9 @@
 package mongo_test
 
 import (
+	"os"
+	"testing"
+
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/coinbase/mongobetween/mongo"
 	"github.com/coinbase/mongobetween/proxy"
@@ -12,8 +15,6 @@ import (
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 )
 
 func insertOpMsg(t *testing.T) *mongo.Message {
@@ -57,7 +58,7 @@ func TestRoundTrip(t *testing.T) {
 
 	msg := insertOpMsg(t)
 
-	res, err := m.RoundTrip(msg, []string{})
+	res, err := m.RoundTrip(msg, []string{}, 0)
 	assert.Nil(t, err)
 
 	single := mongo.ExtractSingleOpMsg(t, res)
@@ -98,7 +99,7 @@ func TestRoundTripProcessError(t *testing.T) {
 
 	msg := insertOpMsg(t)
 
-	res, err := m.RoundTrip(msg, []string{})
+	res, err := m.RoundTrip(msg, []string{}, 0)
 	assert.Nil(t, err)
 
 	single := mongo.ExtractSingleOpMsg(t, res)
@@ -111,7 +112,7 @@ func TestRoundTripProcessError(t *testing.T) {
 	// kill the proxy
 	p.Kill()
 
-	_, err = m.RoundTrip(msg, []string{})
+	_, err = m.RoundTrip(msg, []string{}, 0)
 	assert.Error(t, driver.Error{}, err)
 
 	assert.Equal(t, description.ServerKind(description.Unknown), m.Description().Servers[0].Kind, "Failed to update the server Kind to Unknown")

--- a/mongo/operations.go
+++ b/mongo/operations.go
@@ -357,6 +357,18 @@ func (o *opMsgSectionSequence) String() string {
 	return fmt.Sprintf("{ SectionSingle identifier: %s, msgs: [%s] }", o.identifier, strings.Join(msgs, ", "))
 }
 
+func AssertOpMsgSection(op Operation) []byte {
+	opmsg, _ := op.(*opMsg)
+	section := opmsg.sections[0].(*opMsgSectionSingle)
+	cursorDoc := section.msg.Lookup("cursor").Document()
+
+	if batchDoc := cursorDoc.Lookup("firstBatch").Data; len(batchDoc) > 0 {
+		return batchDoc
+	} else {
+		return cursorDoc.Lookup("nextBatch").Data
+	}
+}
+
 // see https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/x/mongo/driver/operation.go#L1387-L1423
 func decodeMsg(reqID int32, wm []byte) (*opMsg, error) {
 	var ok bool

--- a/mongo/operations.go
+++ b/mongo/operations.go
@@ -75,6 +75,21 @@ func Decode(wm []byte) (Operation, error) {
 	return op, nil
 }
 
+func CopyMessage(msg *Message) (*Message, error) {
+	wmCopy := make([]byte, len(msg.Wm))
+	copy(wmCopy, msg.Wm)
+
+	copyOp, err := Decode(wmCopy)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Message{
+		Wm: wmCopy,
+		Op: copyOp,
+	}, nil
+}
+
 type opUnknown struct {
 	opCode wiremessage.OpCode
 	reqID  int32

--- a/mongo/operations.go
+++ b/mongo/operations.go
@@ -357,7 +357,7 @@ func (o *opMsgSectionSequence) String() string {
 	return fmt.Sprintf("{ SectionSingle identifier: %s, msgs: [%s] }", o.identifier, strings.Join(msgs, ", "))
 }
 
-func AssertOpMsgSection(op Operation) []byte {
+func MustOpMsgCursorSection(op Operation) []byte {
 	opmsg, _ := op.(*opMsg)
 	section := opmsg.sections[0].(*opMsgSectionSingle)
 	cursorDoc := section.msg.Lookup("cursor").Document()

--- a/mongo/operations.go
+++ b/mongo/operations.go
@@ -364,9 +364,8 @@ func MustOpMsgCursorSection(op Operation) []byte {
 
 	if batchDoc := cursorDoc.Lookup("firstBatch").Data; len(batchDoc) > 0 {
 		return batchDoc
-	} else {
-		return cursorDoc.Lookup("nextBatch").Data
 	}
+	return cursorDoc.Lookup("nextBatch").Data
 }
 
 // see https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/x/mongo/driver/operation.go#L1387-L1423

--- a/proxy/dual_reads_test.go
+++ b/proxy/dual_reads_test.go
@@ -1,0 +1,125 @@
+package proxy
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+var (
+	collection = "test_proxy_with_dual_reads"
+)
+
+func setupDualReadClients(t *testing.T) (*observer.ObservedLogs, []*mongo.Client) {
+	json := fmt.Sprintf(`{
+	  "Clusters": {
+		":%d": {
+      "DualReadFrom": ":%d",
+		  "DualReadSamplePercent": 100
+		}
+	  }
+	}`, proxyPort, proxyPort+1)
+	f, err := ioutil.TempFile("", "*.json")
+	assert.Nil(t, err)
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+	_, err = f.Write([]byte(json))
+	assert.Nil(t, err)
+	err = f.Close()
+	assert.Nil(t, err)
+
+	observedZapCore, observedLogs := observer.New(zap.InfoLevel)
+	logger := zap.New(observedZapCore)
+	d, err := NewDynamic(f.Name(), logger)
+	assert.Nil(t, err)
+
+	proxies := setupProxies(t, d, proxyPort, 2)
+	defer func() {
+		for _, p := range proxies {
+			p.Shutdown()
+		}
+	}()
+	for _, p := range proxies {
+		proxy := p
+		proxy.log = logger
+		go func() {
+			err := proxy.Run()
+			assert.Nil(t, err)
+		}()
+	}
+
+	clients := []*mongo.Client{setupClient(t, "localhost", proxyPort), setupClient(t, "localhost", proxyPort+1)}
+	defer func() {
+		for _, client := range clients {
+			err := client.Disconnect(ctx)
+			assert.Nil(t, err)
+		}
+	}()
+
+	var upstreamClients []*mongo.Client
+	if os.Getenv("CI") == "true" {
+		upstreamClients = []*mongo.Client{setupClient(t, "mongo1", 27017), setupClient(t, "mongo2", 27017)}
+	} else {
+		upstreamClients = []*mongo.Client{setupClient(t, "localhost", 27017), setupClient(t, "localhost", 27017+1)}
+	}
+	defer func() {
+		for _, client := range upstreamClients {
+			err := client.Disconnect(ctx)
+			assert.Nil(t, err)
+		}
+	}()
+
+	for _, client := range upstreamClients {
+		collection := client.Database("test").Collection(collection)
+		_, err := collection.DeleteMany(ctx, bson.D{{}})
+		assert.Nil(t, err)
+	}
+
+	return observedLogs, clients
+}
+
+func TestProxyWithDualReads(t *testing.T) {
+	observedLogs, clients := setupDualReadClients(t)
+
+	ash := Trainer{primitive.NewObjectID(), "Ash", 10, "Pallet Town"}
+	misty := Trainer{primitive.NewObjectID(), "Misty", 10, "Cerulean City"}
+	brock := Trainer{primitive.NewObjectID(), "Brock", 15, "Pewter City"}
+
+	_, err := clients[0].Database("test").Collection(collection).InsertOne(ctx, ash)
+	assert.Nil(t, err)
+
+	_, err = clients[1].Database("test").Collection(collection).InsertMany(ctx, []interface{}{ash, misty, brock})
+	assert.Nil(t, err)
+
+	filter := bson.D{{Key: "name", Value: "Ash"}}
+
+	var result Trainer
+	err = clients[0].Database("test").Collection(collection).FindOne(ctx, filter).Decode(&result)
+	assert.Nil(t, err)
+
+	dualReadMatchLogs := observedLogs.FilterMessage("Dual reads match").All()
+	assert.Equal(t, 1, len(dualReadMatchLogs))
+	dualReadMismatchLogs := observedLogs.FilterMessage("Dual reads mismatch").All()
+	assert.Equal(t, 0, len(dualReadMismatchLogs))
+
+	count, err := clients[0].Database("test").Collection(collection).CountDocuments(ctx, bson.D{})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), count)
+	dualReadMatchLogs = observedLogs.FilterMessage("Dual reads match").All()
+	assert.Equal(t, 1, len(dualReadMatchLogs))
+	dualReadMismatchLogs = observedLogs.FilterMessage("Dual reads mismatch").All()
+	assert.Equal(t, 1, len(dualReadMismatchLogs))
+
+	// Test with cursors
+	cursor, err := clients[0].Database("test").Collection(collection).Find(ctx, bson.M{})
+	assert.Nil(t, err)
+}

--- a/proxy/dual_reads_test.go
+++ b/proxy/dual_reads_test.go
@@ -140,10 +140,15 @@ func TestProxyWithDualReads(t *testing.T) {
 
 	ok := cursor.Next(ctx)
 	assert.True(t, ok)
-	cursor.Next(ctx)
+	ok = cursor.Next(ctx)
 	assert.True(t, ok)
-	cursor.Next(ctx)
+	ok = cursor.Next(ctx)
+	assert.True(t, ok)
 	time.Sleep(1 * time.Second)
+	dualReadMatchLogs = observedLogs.FilterMessage("Dual reads match").All()
+	assert.Equal(t, 4, len(dualReadMatchLogs))
+	dualReadMismatchLogs = observedLogs.FilterMessage("Dual reads mismatch").All()
+	assert.Equal(t, 1, len(dualReadMismatchLogs))
 
 	for _, f := range shutdownFuncs {
 		f()

--- a/proxy/dual_reads_test.go
+++ b/proxy/dual_reads_test.go
@@ -148,7 +148,8 @@ func TestProxyWithDualReads(t *testing.T) {
 }
 
 func assertLogs(t *testing.T, logs *observer.ObservedLogs, message string, count int) {
-	ctxTimeout, _ := context.WithTimeout(ctx, 2*time.Second)
+	ctxTimeout, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
 
 	for {
 		select {

--- a/proxy/dynamic.go
+++ b/proxy/dynamic.go
@@ -25,6 +25,8 @@ type DynamicClusters struct {
 type DynamicCluster struct {
 	DisableWrites bool
 	RedirectTo    string
+	DualReadFrom  string
+	DualReadSamplePercent  int
 }
 
 func NewDynamic(url string, log *zap.Logger) (*Dynamic, error) {

--- a/proxy/dynamic.go
+++ b/proxy/dynamic.go
@@ -23,10 +23,10 @@ type DynamicClusters struct {
 }
 
 type DynamicCluster struct {
-	DisableWrites bool
-	RedirectTo    string
-	DualReadFrom  string
-	DualReadSamplePercent  int
+	DisableWrites         bool
+	RedirectTo            string
+	DualReadFrom          string
+	DualReadSamplePercent int
 }
 
 func NewDynamic(url string, log *zap.Logger) (*Dynamic, error) {

--- a/proxy/dynamic_test.go
+++ b/proxy/dynamic_test.go
@@ -14,7 +14,9 @@ func TestDynamic(t *testing.T) {
 	  "Clusters": {
 		":12345": {
 		  "DisableWrites": true,
-		  "RedirectTo": ""
+		  "RedirectTo": "",
+		  "DualReadFrom": "/var/tmp/dual_read.sock",
+		  "DualReadSamplePercent": 51
 		},
 		"/var/tmp/mongo.sock": {
 		  "DisableWrites": false,
@@ -38,12 +40,18 @@ func TestDynamic(t *testing.T) {
 	dy := d.ForAddress(":12345")
 	assert.True(t, dy.DisableWrites)
 	assert.Equal(t, dy.RedirectTo, "")
+	assert.Equal(t, dy.DualReadFrom, "/var/tmp/dual_read.sock")
+	assert.Equal(t, dy.DualReadSamplePercent, 51)
 
 	dy = d.ForAddress("/var/tmp/mongo.sock")
 	assert.False(t, dy.DisableWrites)
 	assert.Equal(t, dy.RedirectTo, "/var/tmp/another.sock")
+	assert.Equal(t, dy.DualReadFrom, "")
+	assert.Equal(t, dy.DualReadSamplePercent, 0)
 
 	dy = d.ForAddress("non-existent")
 	assert.False(t, dy.DisableWrites)
 	assert.Equal(t, dy.RedirectTo, "")
+	assert.Equal(t, dy.DualReadFrom, "")
+	assert.Equal(t, dy.DualReadSamplePercent, 0)
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -16,7 +16,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
 
 	mongob "github.com/coinbase/mongobetween/mongo"
 )
@@ -242,104 +241,6 @@ func TestProxyWithDynamicConfig(t *testing.T) {
 	count, err = upstreamClients[2].Database("test").Collection(collection).CountDocuments(ctx, bson.D{})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(2), count)
-}
-
-func TestProxyWithDualReads(t *testing.T) {
-	collection := "test_proxy_with_dual_reads"
-
-	json := fmt.Sprintf(`{
-	  "Clusters": {
-		":%d": {
-      "DualReadFrom": ":%d",
-		  "DualReadSamplePercent": 100
-		}
-	  }
-	}`, proxyPort, proxyPort+1)
-	f, err := ioutil.TempFile("", "*.json")
-	assert.Nil(t, err)
-	defer func() {
-		_ = os.Remove(f.Name())
-	}()
-	_, err = f.Write([]byte(json))
-	assert.Nil(t, err)
-	err = f.Close()
-	assert.Nil(t, err)
-
-	observedZapCore, observedLogs := observer.New(zap.InfoLevel)
-	logger := zap.New(observedZapCore)
-	d, err := NewDynamic(f.Name(), logger)
-	assert.Nil(t, err)
-
-	proxies := setupProxies(t, d, proxyPort, 2)
-	defer func() {
-		for _, p := range proxies {
-			p.Shutdown()
-		}
-	}()
-	for _, p := range proxies {
-		proxy := p
-		proxy.log = logger
-		go func() {
-			err := proxy.Run()
-			assert.Nil(t, err)
-		}()
-	}
-
-	clients := []*mongo.Client{setupClient(t, "localhost", proxyPort), setupClient(t, "localhost", proxyPort+1)}
-	defer func() {
-		for _, client := range clients {
-			err := client.Disconnect(ctx)
-			assert.Nil(t, err)
-		}
-	}()
-
-	var upstreamClients []*mongo.Client
-	if os.Getenv("CI") == "true" {
-		upstreamClients = []*mongo.Client{setupClient(t, "mongo1", 27017), setupClient(t, "mongo2", 27017)}
-	} else {
-		upstreamClients = []*mongo.Client{setupClient(t, "localhost", 27017), setupClient(t, "localhost", 27017+1)}
-	}
-	defer func() {
-		for _, client := range upstreamClients {
-			err := client.Disconnect(ctx)
-			assert.Nil(t, err)
-		}
-	}()
-
-	for _, client := range upstreamClients {
-		collection := client.Database("test").Collection(collection)
-		_, err := collection.DeleteMany(ctx, bson.D{{}})
-		assert.Nil(t, err)
-	}
-
-	ash := Trainer{primitive.NewObjectID(), "Ash", 10, "Pallet Town"}
-	misty := Trainer{primitive.NewObjectID(), "Misty", 10, "Cerulean City"}
-	brock := Trainer{primitive.NewObjectID(), "Brock", 15, "Pewter City"}
-
-	_, err = clients[0].Database("test").Collection(collection).InsertOne(ctx, ash)
-	assert.Nil(t, err)
-
-	_, err = clients[1].Database("test").Collection(collection).InsertMany(ctx, []interface{}{ash, misty, brock})
-	assert.Nil(t, err)
-
-	filter := bson.D{{Key: "name", Value: "Ash"}}
-
-	var result Trainer
-	err = clients[0].Database("test").Collection(collection).FindOne(ctx, filter).Decode(&result)
-	assert.Nil(t, err)
-
-	dualReadMatchLogs := observedLogs.FilterMessage("Dual reads match").All()
-	assert.Equal(t, 1, len(dualReadMatchLogs))
-	dualReadMismatchLogs := observedLogs.FilterMessage("Dual reads mismatch").All()
-	assert.Equal(t, 0, len(dualReadMismatchLogs))
-
-	count, err := clients[0].Database("test").Collection(collection).CountDocuments(ctx, bson.D{})
-	assert.Nil(t, err)
-	assert.Equal(t, int64(1), count)
-	dualReadMatchLogs = observedLogs.FilterMessage("Dual reads match").All()
-	assert.Equal(t, 1, len(dualReadMatchLogs))
-	dualReadMismatchLogs = observedLogs.FilterMessage("Dual reads mismatch").All()
-	assert.Equal(t, 1, len(dualReadMismatchLogs))
 }
 
 func setupProxy(t *testing.T) *Proxy {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -125,7 +125,8 @@ func TestProxyUnacknowledgedWrites(t *testing.T) {
 
 	// Insert a document using the setup collection and ensure document count is 2. Doing this ensures that the proxy
 	// did not crash while processing the unacknowledged write.
-	_, err = setupCollection.InsertOne(ctx, ash)
+	misty := Trainer{primitive.NewObjectID(), "Misty", 10, "Cerulean City"}
+	_, err = setupCollection.InsertOne(ctx, misty)
 	assert.Nil(t, err)
 
 	count, err := setupCollection.CountDocuments(ctx, bson.D{})

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -11,10 +11,12 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/writeconcern"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 
 	mongob "github.com/coinbase/mongobetween/mongo"
 )
@@ -25,6 +27,7 @@ var (
 )
 
 type Trainer struct {
+	ID   primitive.ObjectID `bson:"_id"`
 	Name string
 	Age  int
 	City string
@@ -43,9 +46,9 @@ func TestProxy(t *testing.T) {
 	_, err := collection.DeleteMany(ctx, bson.D{{}})
 	assert.Nil(t, err)
 
-	ash := Trainer{"Ash", 10, "Pallet Town"}
-	misty := Trainer{"Misty", 10, "Cerulean City"}
-	brock := Trainer{"Brock", 15, "Pewter City"}
+	ash := Trainer{primitive.NewObjectID(), "Ash", 10, "Pallet Town"}
+	misty := Trainer{primitive.NewObjectID(), "Misty", 10, "Cerulean City"}
+	brock := Trainer{primitive.NewObjectID(), "Brock", 15, "Pewter City"}
 
 	_, err = collection.InsertOne(ctx, ash)
 	assert.Nil(t, err)
@@ -117,7 +120,7 @@ func TestProxyUnacknowledgedWrites(t *testing.T) {
 	_, err = setupCollection.DeleteMany(ctx, bson.D{})
 	assert.Nil(t, err)
 
-	ash := Trainer{"Ash", 10, "Pallet Town"}
+	ash := Trainer{primitive.NewObjectID(), "Ash", 10, "Pallet Town"}
 	_, err = unackCollection.InsertOne(ctx, ash)
 	assert.Equal(t, mongo.ErrUnacknowledgedWrite, err) // driver returns a special error value for w=0 writes
 
@@ -204,9 +207,9 @@ func TestProxyWithDynamicConfig(t *testing.T) {
 		assert.Nil(t, err)
 	}
 
-	ash := Trainer{"Ash", 10, "Pallet Town"}
-	misty := Trainer{"Misty", 10, "Cerulean City"}
-	brock := Trainer{"Brock", 15, "Pewter City"}
+	ash := Trainer{primitive.NewObjectID(), "Ash", 10, "Pallet Town"}
+	misty := Trainer{primitive.NewObjectID(), "Misty", 10, "Cerulean City"}
+	brock := Trainer{primitive.NewObjectID(), "Brock", 15, "Pewter City"}
 
 	// expect write error
 	_, err = clients[0].Database("test").Collection(collection).InsertOne(ctx, ash)
@@ -239,6 +242,104 @@ func TestProxyWithDynamicConfig(t *testing.T) {
 	count, err = upstreamClients[2].Database("test").Collection(collection).CountDocuments(ctx, bson.D{})
 	assert.Nil(t, err)
 	assert.Equal(t, int64(2), count)
+}
+
+func TestProxyWithDualReads(t *testing.T) {
+	collection := "test_proxy_with_dual_reads"
+
+	json := fmt.Sprintf(`{
+	  "Clusters": {
+		":%d": {
+      "DualReadFrom": ":%d",
+		  "DualReadSamplePercent": 100
+		}
+	  }
+	}`, proxyPort, proxyPort+1)
+	f, err := ioutil.TempFile("", "*.json")
+	assert.Nil(t, err)
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+	_, err = f.Write([]byte(json))
+	assert.Nil(t, err)
+	err = f.Close()
+	assert.Nil(t, err)
+
+	observedZapCore, observedLogs := observer.New(zap.InfoLevel)
+	logger := zap.New(observedZapCore)
+	d, err := NewDynamic(f.Name(), logger)
+	assert.Nil(t, err)
+
+	proxies := setupProxies(t, d, proxyPort, 2)
+	defer func() {
+		for _, p := range proxies {
+			p.Shutdown()
+		}
+	}()
+	for _, p := range proxies {
+		proxy := p
+		proxy.log = logger
+		go func() {
+			err := proxy.Run()
+			assert.Nil(t, err)
+		}()
+	}
+
+	clients := []*mongo.Client{setupClient(t, "localhost", proxyPort), setupClient(t, "localhost", proxyPort+1)}
+	defer func() {
+		for _, client := range clients {
+			err := client.Disconnect(ctx)
+			assert.Nil(t, err)
+		}
+	}()
+
+	var upstreamClients []*mongo.Client
+	if os.Getenv("CI") == "true" {
+		upstreamClients = []*mongo.Client{setupClient(t, "mongo1", 27017), setupClient(t, "mongo2", 27017)}
+	} else {
+		upstreamClients = []*mongo.Client{setupClient(t, "localhost", 27017), setupClient(t, "localhost", 27017+1)}
+	}
+	defer func() {
+		for _, client := range upstreamClients {
+			err := client.Disconnect(ctx)
+			assert.Nil(t, err)
+		}
+	}()
+
+	for _, client := range upstreamClients {
+		collection := client.Database("test").Collection(collection)
+		_, err := collection.DeleteMany(ctx, bson.D{{}})
+		assert.Nil(t, err)
+	}
+
+	ash := Trainer{primitive.NewObjectID(), "Ash", 10, "Pallet Town"}
+	misty := Trainer{primitive.NewObjectID(), "Misty", 10, "Cerulean City"}
+	brock := Trainer{primitive.NewObjectID(), "Brock", 15, "Pewter City"}
+
+	_, err = clients[0].Database("test").Collection(collection).InsertOne(ctx, ash)
+	assert.Nil(t, err)
+
+	_, err = clients[1].Database("test").Collection(collection).InsertMany(ctx, []interface{}{ash, misty, brock})
+	assert.Nil(t, err)
+
+	filter := bson.D{{Key: "name", Value: "Ash"}}
+
+	var result Trainer
+	err = clients[0].Database("test").Collection(collection).FindOne(ctx, filter).Decode(&result)
+	assert.Nil(t, err)
+
+	dualReadMatchLogs := observedLogs.FilterMessage("Dual reads match").All()
+	assert.Equal(t, 1, len(dualReadMatchLogs))
+	dualReadMismatchLogs := observedLogs.FilterMessage("Dual reads mismatch").All()
+	assert.Equal(t, 0, len(dualReadMismatchLogs))
+
+	count, err := clients[0].Database("test").Collection(collection).CountDocuments(ctx, bson.D{})
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), count)
+	dualReadMatchLogs = observedLogs.FilterMessage("Dual reads match").All()
+	assert.Equal(t, 1, len(dualReadMatchLogs))
+	dualReadMismatchLogs = observedLogs.FilterMessage("Dual reads mismatch").All()
+	assert.Equal(t, 1, len(dualReadMismatchLogs))
 }
 
 func setupProxy(t *testing.T) *Proxy {

--- a/util/statsd_test.go
+++ b/util/statsd_test.go
@@ -1,8 +1,8 @@
 package util_test
 
 import (
-	"github.com/coinbase/mongobetween/util"
 	"github.com/DataDog/datadog-go/statsd"
+	"github.com/coinbase/mongobetween/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"sync"


### PR DESCRIPTION
This PR adds support for dual reads, which allows us to make reads to a migrated cluster and verify performance/correctness in a way that is invisible to the application.

The second round trip is made after the socket write and the client should see no change in latency with dual reads enabled.