### PR TITLE
Use SDAM for MongoBetween( v2 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Usage: mongobetween [OPTIONS] address1=uri1 [address2=uri2] ...
     	MongoDB username
   -dynamic string
     	File or URL to query for dynamic configuration
+  -enable-sdam-metrics
+        Enable SDAM(Server Discovery And Monitoring) metrics
+  -enable-sdam-logging
+        Enable SDAM(Server Discovery And Monitoring) logging
 ```
 
 TCP socket example:

--- a/config/config.go
+++ b/config/config.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
+	"github.com/coinbase/mongobetween/util"
+	"go.mongodb.org/mongo-driver/event"
 	"os"
 	"regexp"
 	"strings"
@@ -29,9 +32,10 @@ type Config struct {
 	ping    bool
 	pretty  bool
 	clients []client
-	statsd  string
 	level   zapcore.Level
 	dynamic string
+	logger  *zap.Logger
+	statsd  *statsd.Client
 }
 
 type client struct {
@@ -58,12 +62,15 @@ func (c *Config) Pretty() bool {
 	return c.pretty
 }
 
-func (c *Config) Proxies(log *zap.Logger) (proxies []*proxy.Proxy, err error) {
-	sd, err := statsd.New(c.statsd, statsd.WithNamespace("mongobetween"))
-	if err != nil {
-		return nil, err
-	}
+func (c *Config) Logger() *zap.Logger {
+	return c.logger
+}
 
+func (c *Config) Statsd() *statsd.Client {
+	return c.statsd
+}
+
+func (c *Config) Proxies(log *zap.Logger) (proxies []*proxy.Proxy, err error) {
 	d, err := proxy.NewDynamic(c.dynamic, log)
 	if err != nil {
 		return nil, err
@@ -71,7 +78,7 @@ func (c *Config) Proxies(log *zap.Logger) (proxies []*proxy.Proxy, err error) {
 
 	mongos := make(map[string]*mongo.Mongo)
 	for _, client := range c.clients {
-		m, err := mongo.Connect(log, sd, client.opts, c.ping)
+		m, err := mongo.Connect(log, c.statsd, client.opts, c.ping)
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +89,7 @@ func (c *Config) Proxies(log *zap.Logger) (proxies []*proxy.Proxy, err error) {
 	}
 
 	for _, client := range c.clients {
-		p, err := proxy.NewProxy(log, sd, client.label, c.network, client.address, c.unlink, mongoLookup, d)
+		p, err := proxy.NewProxy(log, c.statsd, client.label, c.network, client.address, c.unlink, mongoLookup, d)
 		if err != nil {
 			return nil, err
 		}
@@ -106,7 +113,7 @@ func parseFlags() (*Config, error) {
 		flag.PrintDefaults()
 	}
 
-	var unlink, ping, pretty bool
+	var unlink, ping, pretty, enableSdamMetrics, enableSdamLogging bool
 	var network, username, password, stats, loglevel, dynamic string
 	flag.StringVar(&network, "network", "tcp4", "One of: tcp, tcp4, tcp6, unix or unixpacket")
 	flag.StringVar(&username, "username", "", "MongoDB username")
@@ -117,6 +124,8 @@ func parseFlags() (*Config, error) {
 	flag.BoolVar(&pretty, "pretty", false, "Pretty print logging")
 	flag.StringVar(&loglevel, "loglevel", "info", "One of: debug, info, warn, error, dpanic, panic, fatal")
 	flag.StringVar(&dynamic, "dynamic", "", "File or URL to query for dynamic configuration")
+	flag.BoolVar(&enableSdamMetrics, "enable-sdam-metrics", false, "Enable SDAM(Server Discovery And Monitoring) metrics")
+	flag.BoolVar(&enableSdamLogging, "enable-sdam-logging", false, "Enable SDAM(Server Discovery And Monitoring) logging")
 
 	flag.Parse()
 
@@ -161,12 +170,19 @@ func parseFlags() (*Config, error) {
 		return nil, errors.New("missing address=uri(s)")
 	}
 
+	loggerClient := newLogger(level, pretty)
+	statsdClient, err := statsd.New(stats, statsd.WithNamespace("mongobetween"))
+	if err != nil {
+		return nil, err
+	}
+
 	var clients []client
 	for address, uri := range addressMap {
 		label, opts, err := clientOptions(uri, username, password)
 		if err != nil {
 			return nil, err
 		}
+		initMonitoring(opts, statsdClient, loggerClient, enableSdamMetrics, enableSdamLogging)
 		clients = append(clients, client{
 			address: address,
 			label:   label,
@@ -180,9 +196,10 @@ func parseFlags() (*Config, error) {
 		ping:    ping,
 		pretty:  pretty,
 		clients: clients,
-		statsd:  stats,
 		level:   level,
 		dynamic: dynamic,
+		logger:  loggerClient,
+		statsd:  statsdClient,
 	}, nil
 }
 
@@ -232,6 +249,15 @@ func clientOptions(uri, username, password string) (string, *options.ClientOptio
 	return label, opts, nil
 }
 
+func initMonitoring(opts *options.ClientOptions, statsd *statsd.Client, logger *zap.Logger, enableSdamMetrics bool, enableSdamLogging bool) *options.ClientOptions {
+	// set up monitors
+	opts = opts.SetPoolMonitor(poolMonitor(statsd))
+
+	opts = opts.SetServerMonitor(serverMonitoring(logger, statsd, enableSdamMetrics, enableSdamLogging))
+
+	return opts
+}
+
 func uriWorkaround(uri, username string) string {
 	// Workaround for a feature in the Mongo driver URI parsing where you can't set a URI
 	// without setting the username ("error parsing uri: authsource without username is
@@ -247,4 +273,148 @@ func uriWorkaround(uri, username string) string {
 		}
 	}
 	return uri
+}
+
+func newLogger(level zapcore.Level, pretty bool) *zap.Logger {
+	var c zap.Config
+	if pretty {
+		c = zap.NewDevelopmentConfig()
+		c.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	} else {
+		c = zap.NewProductionConfig()
+	}
+
+	c.EncoderConfig.MessageKey = "message"
+	c.Level.SetLevel(level)
+
+	log, err := c.Build(zap.AddStacktrace(zap.FatalLevel))
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
+		os.Exit(1)
+	}
+
+	return log
+}
+
+func poolMonitor(sd *statsd.Client) *event.PoolMonitor {
+	checkedOut, checkedIn := util.StatsdBackgroundGauge(sd, "pool.checked_out_connections", []string{})
+	opened, closed := util.StatsdBackgroundGauge(sd, "pool.open_connections", []string{})
+
+	return &event.PoolMonitor{
+		Event: func(e *event.PoolEvent) {
+			snake := strings.ToLower(regexp.MustCompile("([a-z0-9])([A-Z])").ReplaceAllString(e.Type, "${1}_${2}"))
+			name := fmt.Sprintf("pool_event.%s", snake)
+			tags := []string{
+				fmt.Sprintf("address:%s", e.Address),
+				fmt.Sprintf("reason:%s", e.Reason),
+			}
+			switch e.Type {
+			case event.ConnectionCreated:
+				opened(name, tags)
+			case event.ConnectionClosed:
+				closed(name, tags)
+			case event.GetSucceeded:
+				checkedOut(name, tags)
+			case event.ConnectionReturned:
+				checkedIn(name, tags)
+			default:
+				_ = sd.Incr(name, tags, 1)
+			}
+		},
+	}
+}
+
+func serverMonitoring(log *zap.Logger, statsdClient *statsd.Client, enableSdamMetrics bool, enableSdamLogging bool) *event.ServerMonitor {
+
+	return &event.ServerMonitor{
+
+		ServerOpening: func(e *event.ServerOpeningEvent) {
+			if enableSdamMetrics == true {
+				_ = statsdClient.Incr("server_opening_event",
+					[]string{
+						fmt.Sprintf("address:%s", e.Address),
+						fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
+					}, 0)
+			}
+		},
+
+		ServerClosed: func(e *event.ServerClosedEvent) {
+			if enableSdamMetrics {
+				_ = statsdClient.Incr("server_closed_event",
+					[]string{
+						fmt.Sprintf("address:%s", e.Address),
+						fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
+					}, 0)
+			}
+		},
+
+		ServerDescriptionChanged: func(e *event.ServerDescriptionChangedEvent) {
+			if enableSdamMetrics {
+				_ = statsdClient.Incr("server_description_changed_event",
+					[]string{
+						fmt.Sprintf("address:%s", e.Address),
+						fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
+					}, 0)
+			}
+
+			if enableSdamLogging {
+				var prevDMap map[string]interface{}
+				var newDMap map[string]interface{}
+
+				prevDescription, _ := json.Marshal(&e.PreviousDescription)
+				_ = json.Unmarshal(prevDescription, &prevDMap)
+				newDescription, _ := json.Marshal(e.NewDescription)
+				_ = json.Unmarshal(newDescription, &newDMap)
+
+				log.Info("ServerDescriptionChangedEvent detected. ",
+					zap.Any("address", e.Address),
+					zap.String("topologyId", e.TopologyID.Hex()),
+					zap.Any("prevDescription", prevDMap),
+					zap.Any("newDescription", newDMap),
+				)
+			}
+		},
+
+		TopologyDescriptionChanged: func(e *event.TopologyDescriptionChangedEvent) {
+			if enableSdamMetrics {
+				_ = statsdClient.Incr("topology_description_changed_event",
+					[]string{
+						fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
+					}, 0)
+			}
+			if enableSdamLogging {
+				var prevDMap map[string]interface{}
+				var newDMap map[string]interface{}
+
+				prevDescription, _ := json.Marshal(&e.PreviousDescription)
+				_ = json.Unmarshal(prevDescription, &prevDMap)
+				newDescription, _ := json.Marshal(e.NewDescription)
+				_ = json.Unmarshal(newDescription, &newDMap)
+
+				log.Info("TopologyDescriptionChangedEvent detected. ",
+					zap.String("topologyId", e.TopologyID.Hex()),
+					zap.Any("prevDescription", prevDMap),
+					zap.Any("newDescription", newDMap),
+				)
+			}
+		},
+
+		TopologyOpening: func(e *event.TopologyOpeningEvent) {
+			if enableSdamMetrics {
+				_ = statsdClient.Incr("topology_opening_event",
+					[]string{
+						fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
+					}, 0)
+			}
+		},
+
+		TopologyClosed: func(e *event.TopologyClosedEvent) {
+			if enableSdamMetrics {
+				_ = statsdClient.Incr("topology_closed_event",
+					[]string{
+						fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
+					}, 0)
+			}
+		},
+	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/coinbase/mongobetween/util"
 	"go.mongodb.org/mongo-driver/event"
 	"os"
 	"regexp"
@@ -19,6 +18,7 @@ import (
 
 	"github.com/coinbase/mongobetween/mongo"
 	"github.com/coinbase/mongobetween/proxy"
+	"github.com/coinbase/mongobetween/util"
 )
 
 const usernamePlaceholder = "_"
@@ -250,11 +250,9 @@ func clientOptions(uri, username, password string) (string, *options.ClientOptio
 }
 
 func initMonitoring(opts *options.ClientOptions, statsd *statsd.Client, logger *zap.Logger, enableSdamMetrics bool, enableSdamLogging bool) *options.ClientOptions {
-	// set up monitors
+	// set up monitors for Pool and Server(SDAM)
 	opts = opts.SetPoolMonitor(poolMonitor(statsd))
-
 	opts = opts.SetServerMonitor(serverMonitoring(logger, statsd, enableSdamMetrics, enableSdamLogging))
-
 	return opts
 }
 
@@ -327,7 +325,6 @@ func poolMonitor(sd *statsd.Client) *event.PoolMonitor {
 func serverMonitoring(log *zap.Logger, statsdClient *statsd.Client, enableSdamMetrics bool, enableSdamLogging bool) *event.ServerMonitor {
 
 	return &event.ServerMonitor{
-
 		ServerOpening: func(e *event.ServerOpeningEvent) {
 			if enableSdamMetrics == true {
 				_ = statsdClient.Incr("server_opening_event",

--- a/config/config.go
+++ b/config/config.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"go.mongodb.org/mongo-driver/event"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/DataDog/datadog-go/statsd"
+	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 	"go.uber.org/zap"

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -2,21 +2,17 @@ package mongo
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
 	"os"
 	"reflect"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
 	"unsafe"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/coinbase/mongobetween/util"
-	"go.mongodb.org/mongo-driver/event"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
@@ -62,12 +58,6 @@ func Connect(log *zap.Logger, sd *statsd.Client, opts *options.ClientOptions, pi
 	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
 	defer cancel()
 
-	opts = opts.SetPoolMonitor(poolMonitor(sd))
-
-	if envVarIsTrue("ENABLE_SERVER_MONITORING") {
-		opts = opts.SetServerMonitor(serverMonitoring(log, sd))
-	}
-
 	var err error
 	log.Info("Connect")
 	c, err := mongo.Connect(ctx, opts)
@@ -102,117 +92,6 @@ func Connect(log *zap.Logger, sd *statsd.Client, opts *options.ClientOptions, pi
 	go m.cacheMonitor()
 
 	return &m, nil
-}
-
-func poolMonitor(sd *statsd.Client) *event.PoolMonitor {
-	checkedOut, checkedIn := util.StatsdBackgroundGauge(sd, "pool.checked_out_connections", []string{})
-	opened, closed := util.StatsdBackgroundGauge(sd, "pool.open_connections", []string{})
-
-	return &event.PoolMonitor{
-		Event: func(e *event.PoolEvent) {
-			snake := strings.ToLower(regexp.MustCompile("([a-z0-9])([A-Z])").ReplaceAllString(e.Type, "${1}_${2}"))
-			name := fmt.Sprintf("pool_event.%s", snake)
-			tags := []string{
-				fmt.Sprintf("address:%s", e.Address),
-				fmt.Sprintf("reason:%s", e.Reason),
-			}
-			switch e.Type {
-			case event.ConnectionCreated:
-				opened(name, tags)
-			case event.ConnectionClosed:
-				closed(name, tags)
-			case event.GetSucceeded:
-				checkedOut(name, tags)
-			case event.ConnectionReturned:
-				checkedIn(name, tags)
-			default:
-				_ = sd.Incr(name, tags, 1)
-			}
-		},
-	}
-}
-
-func serverMonitoring(log *zap.Logger, statsdClient *statsd.Client) *event.ServerMonitor {
-
-	return &event.ServerMonitor{
-
-		ServerOpening: func(e *event.ServerOpeningEvent) {
-			_ = statsdClient.Incr("server_opening_event",
-				[]string{
-					fmt.Sprintf("address:%s", e.Address),
-					fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
-				}, 0)
-		},
-
-		ServerClosed: func(e *event.ServerClosedEvent) {
-			_ = statsdClient.Incr("server_closed_event",
-				[]string{
-					fmt.Sprintf("address:%s", e.Address),
-					fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
-				}, 0)
-		},
-
-		ServerDescriptionChanged: func(e *event.ServerDescriptionChangedEvent) {
-			_ = statsdClient.Incr("server_description_changed_event",
-				[]string{
-					fmt.Sprintf("address:%s", e.Address),
-					fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
-				}, 0)
-
-			if envVarIsTrue("ENABLE_SERVER_MONITORING_LOGGING") {
-				var prevDMap map[string]interface{}
-				var newDMap map[string]interface{}
-
-				prevDescription, _ := json.Marshal(&e.PreviousDescription)
-				_ = json.Unmarshal(prevDescription, &prevDMap)
-				newDescription, _ := json.Marshal(e.NewDescription)
-				_ = json.Unmarshal(newDescription, &newDMap)
-
-				log.Info("ServerDescriptionChangedEvent detected. ",
-					zap.Any("address", e.Address),
-					zap.String("topologyId", e.TopologyID.Hex()),
-					zap.Any("prevDescription", prevDMap),
-					zap.Any("newDescription", newDMap),
-				)
-			}
-		},
-
-		TopologyDescriptionChanged: func(e *event.TopologyDescriptionChangedEvent) {
-			_ = statsdClient.Incr("topology_description_changed_event",
-				[]string{
-					fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
-				}, 0)
-			if envVarIsTrue("ENABLE_SERVER_MONITORING_LOGGING") {
-				var prevDMap map[string]interface{}
-				var newDMap map[string]interface{}
-
-				prevDescription, _ := json.Marshal(&e.PreviousDescription)
-				_ = json.Unmarshal(prevDescription, &prevDMap)
-				newDescription, _ := json.Marshal(e.NewDescription)
-				_ = json.Unmarshal(newDescription, &newDMap)
-
-				log.Info("TopologyDescriptionChangedEvent detected. ",
-					zap.String("topologyId", e.TopologyID.Hex()),
-					zap.Any("prevDescription", prevDMap),
-					zap.Any("newDescription", newDMap),
-				)
-			}
-		},
-
-		TopologyOpening: func(e *event.TopologyOpeningEvent) {
-			_ = statsdClient.Incr("topology_opening_event",
-				[]string{
-					fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
-				}, 0)
-		},
-
-		TopologyClosed: func(e *event.TopologyClosedEvent) {
-			_ = statsdClient.Incr("topology_closed_event",
-				[]string{
-					fmt.Sprintf("topology_id:%s", e.TopologyID.Hex()),
-				}, 0)
-		},
-	}
 }
 
 func (m *Mongo) Description() description.Topology {

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -137,7 +137,7 @@ func serverMonitoring(log *zap.Logger, statsdClient *statsd.Client) *event.Serve
 	return &event.ServerMonitor{
 
 		ServerDescriptionChanged: func(e *event.ServerDescriptionChangedEvent) {
-			statsdClient.Incr("server_description_changed_event",
+			_ = statsdClient.Incr("server_description_changed_event",
 				[]string{
 					fmt.Sprintf("address:%s", e.Address),
 					fmt.Sprintf("topology_id:%s", e.TopologyID),
@@ -154,7 +154,7 @@ func serverMonitoring(log *zap.Logger, statsdClient *statsd.Client) *event.Serve
 		},
 
 		TopologyDescriptionChanged: func(e *event.TopologyDescriptionChangedEvent) {
-			statsdClient.Incr("topology_description_changed_event",
+			_ = statsdClient.Incr("topology_description_changed_event",
 				[]string{
 					fmt.Sprintf("topology_id:%s", e.TopologyID),
 				}, 0)
@@ -168,14 +168,14 @@ func serverMonitoring(log *zap.Logger, statsdClient *statsd.Client) *event.Serve
 		},
 
 		TopologyOpening: func(e *event.TopologyOpeningEvent) {
-			statsdClient.Incr("topology_opening_event",
+			_ = statsdClient.Incr("topology_opening_event",
 				[]string{
 					fmt.Sprintf("topology_id:%s", e.TopologyID),
 				}, 0)
 		},
 
 		TopologyClosed: func(e *event.TopologyClosedEvent) {
-			statsdClient.Incr("topology_closed_event",
+			_ = statsdClient.Incr("topology_closed_event",
 				[]string{
 					fmt.Sprintf("topology_id:%s", e.TopologyID),
 				}, 0)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
-	"os"
 	"reflect"
-	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -46,11 +44,6 @@ func extractTopology(c *mongo.Client) *topology.Topology {
 	d := e.FieldByName("deployment")
 	d = reflect.NewAt(d.Type(), unsafe.Pointer(d.UnsafeAddr())).Elem() // #nosec G103
 	return d.Interface().(*topology.Topology)
-}
-
-func envVarIsTrue(envVar string) bool {
-	return os.Getenv(envVar) == "1" ||
-		strings.ToLower(os.Getenv(envVar)) == "true"
 }
 
 func Connect(log *zap.Logger, sd *statsd.Client, opts *options.ClientOptions, ping bool) (*Mongo, error) {

--- a/mongobetween.go
+++ b/mongobetween.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"go.uber.org/zap/zapcore"
 	"os"
 	"os/signal"
 	"sync"
@@ -16,33 +15,13 @@ import (
 
 func main() {
 	c := config.ParseFlags()
-	log := newLogger(c.LogLevel(), c.Pretty())
-	run(log, c)
+	run(c)
 }
 
-func newLogger(level zapcore.Level, pretty bool) *zap.Logger {
-	var c zap.Config
-	if pretty {
-		c = zap.NewDevelopmentConfig()
-		c.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	} else {
-		c = zap.NewProductionConfig()
-	}
+func run(config *config.Config) {
+	proxies, err := config.Proxies(config.Logger())
+	log := config.Logger()
 
-	c.EncoderConfig.MessageKey = "message"
-	c.Level.SetLevel(level)
-
-	log, err := c.Build(zap.AddStacktrace(zap.FatalLevel))
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
-		os.Exit(1)
-	}
-
-	return log
-}
-
-func run(log *zap.Logger, config *config.Config) {
-	proxies, err := config.Proxies(log)
 	if err != nil {
 		log.Fatal("Startup error", zap.Error(err))
 	}


### PR DESCRIPTION
The idea here is to enable SDAM(Server Discovery And Monitoring) on the MongoBetween side so it can report back metrics and logs on what it observes about server and topology changes on the Atlas side.

This will be helpful for understanding the state of the cluster from MongoBetween's perspective during times of connectivity issues.

SDAM References:

https://www.alexbevi.com/blog/2022/05/15/mongodb-driver-monitoring/#go

https://github.com/mongodb/specifications/blob/a9096ad069e8af0f5973c9d0ca75da57e4c63616/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events