### PR TITLE
Use SDAM for MongoBetween( v3 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Usage: mongobetween [OPTIONS] address1=uri1 [address2=uri2] ...
     	MongoDB username
   -dynamic string
     	File or URL to query for dynamic configuration
+  -enable-sdam-metrics
+        Enable SDAM(Server Discovery And Monitoring) metrics
+  -enable-sdam-logging
+        Enable SDAM(Server Discovery And Monitoring) logging
 ```
 
 TCP socket example:

--- a/mongobetween.go
+++ b/mongobetween.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"go.uber.org/zap/zapcore"
 	"os"
 	"os/signal"
 	"sync"
@@ -16,33 +15,13 @@ import (
 
 func main() {
 	c := config.ParseFlags()
-	log := newLogger(c.LogLevel(), c.Pretty())
-	run(log, c)
+	run(c)
 }
 
-func newLogger(level zapcore.Level, pretty bool) *zap.Logger {
-	var c zap.Config
-	if pretty {
-		c = zap.NewDevelopmentConfig()
-		c.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	} else {
-		c = zap.NewProductionConfig()
-	}
+func run(config *config.Config) {
+	proxies, err := config.Proxies(config.Logger())
+	log := config.Logger()
 
-	c.EncoderConfig.MessageKey = "message"
-	c.Level.SetLevel(level)
-
-	log, err := c.Build(zap.AddStacktrace(zap.FatalLevel))
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
-		os.Exit(1)
-	}
-
-	return log
-}
-
-func run(log *zap.Logger, config *config.Config) {
-	proxies, err := config.Proxies(log)
 	if err != nil {
 		log.Fatal("Startup error", zap.Error(err))
 	}


### PR DESCRIPTION
The idea here is to enable SDAM(Server Discovery And Monitoring) on the MongoBetween side so it can report back metrics and logs on what it observes about server and topology changes on the Atlas side.

This will be helpful for understanding the state of the cluster from MongoBetween's perspective during times of connectivity issues.

SDAM References:

https://www.alexbevi.com/blog/2022/05/15/mongodb-driver-monitoring/#go

https://github.com/mongodb/specifications/blob/a9096ad069e8af0f5973c9d0ca75da57e4c63616/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events