### PR TITLE
Add SDAM(Server Discovery And Monitoring) capabilities for MongoBetween

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Usage: mongobetween [OPTIONS] address1=uri1 [address2=uri2] ...
     	MongoDB username
   -dynamic string
     	File or URL to query for dynamic configuration
+  -enable-sdam-metrics
+        Enable SDAM(Server Discovery And Monitoring) metrics
+  -enable-sdam-logging
+        Enable SDAM(Server Discovery And Monitoring) logging
 ```
 
 TCP socket example:
@@ -76,33 +80,33 @@ This will disable writes to the proxy served from address `:12345`, and redirect
 ### TODO
 
 Current known missing features:
- - [X] Transaction server pinning
- - [X] Different cursors on separate servers with the same cursor ID value
+- [X] Transaction server pinning
+- [X] Different cursors on separate servers with the same cursor ID value
 
 
 ### Statsd
 `mongobetween` supports reporting health metrics to a local statsd sidecar, using the [Datadog Go library](github.com/DataDog/datadog-go). By default it reports to `localhost:8125`. The following metrics are reported:
- - `mongobetween.handle_message` (Timing) - end-to-end time handling an incoming message from the application
- - `mongobetween.round_trip` (Timing) - round trip time sending a request and receiving a response from MongoDB
- - `mongobetween.request_size` (Distribution) - request size to MongoDB
- - `mongobetween.response_size` (Distribution) - response size from MongoDB
- - `mongobetween.open_connections` (Gauge) - number of open connections between the proxy and the application
- - `mongobetween.connection_opened` (Counter) - connection opened with the application
- - `mongobetween.connection_closed` (Counter) - connection closed with the application
- - `mongobetween.cursors` (Gauge) - number of open cursors being tracked (for cursor -> server mapping)
- - `mongobetween.transactions` (Gauge) - number of transactions being tracked (for client sessions -> server mapping)****
- - `mongobetween.server_selection` (Timing) - Go driver server selection timing
- - `mongobetween.checkout_connection` (Timing) - Go driver connection checkout timing
- - `mongobetween.pool.checked_out_connections` (Gauge) - number of connections checked out from the Go driver connection pool
- - `mongobetween.pool.open_connections` (Gauge) - number of open connections from the Go driver to MongoDB
- - `mongobetween.pool_event.connection_closed` (Counter) - Go driver connection closed
- - `mongobetween.pool_event.connection_pool_created` (Counter) - Go driver connection pool created
- - `mongobetween.pool_event.connection_created` (Counter) - Go driver connection created
- - `mongobetween.pool_event.connection_check_out_failed` (Counter) - Go driver connection check out failed
- - `mongobetween.pool_event.connection_checked_out` (Counter) - Go driver connection checked out
- - `mongobetween.pool_event.connection_checked_in` (Counter) - Go driver connection checked in
- - `mongobetween.pool_event.connection_pool_cleared` (Counter) - Go driver connection pool cleared
- - `mongobetween.pool_event.connection_pool_closed` (Counter) - Go driver connection pool closed
+- `mongobetween.handle_message` (Timing) - end-to-end time handling an incoming message from the application
+- `mongobetween.round_trip` (Timing) - round trip time sending a request and receiving a response from MongoDB
+- `mongobetween.request_size` (Distribution) - request size to MongoDB
+- `mongobetween.response_size` (Distribution) - response size from MongoDB
+- `mongobetween.open_connections` (Gauge) - number of open connections between the proxy and the application
+- `mongobetween.connection_opened` (Counter) - connection opened with the application
+- `mongobetween.connection_closed` (Counter) - connection closed with the application
+- `mongobetween.cursors` (Gauge) - number of open cursors being tracked (for cursor -> server mapping)
+- `mongobetween.transactions` (Gauge) - number of transactions being tracked (for client sessions -> server mapping)****
+- `mongobetween.server_selection` (Timing) - Go driver server selection timing
+- `mongobetween.checkout_connection` (Timing) - Go driver connection checkout timing
+- `mongobetween.pool.checked_out_connections` (Gauge) - number of connections checked out from the Go driver connection pool
+- `mongobetween.pool.open_connections` (Gauge) - number of open connections from the Go driver to MongoDB
+- `mongobetween.pool_event.connection_closed` (Counter) - Go driver connection closed
+- `mongobetween.pool_event.connection_pool_created` (Counter) - Go driver connection pool created
+- `mongobetween.pool_event.connection_created` (Counter) - Go driver connection created
+- `mongobetween.pool_event.connection_check_out_failed` (Counter) - Go driver connection check out failed
+- `mongobetween.pool_event.connection_checked_out` (Counter) - Go driver connection checked out
+- `mongobetween.pool_event.connection_checked_in` (Counter) - Go driver connection checked in
+- `mongobetween.pool_event.connection_pool_cleared` (Counter) - Go driver connection pool cleared
+- `mongobetween.pool_event.connection_pool_closed` (Counter) - Go driver connection pool closed
 
 ### Background
 `mongobetween` was built to address a connection storm issue between a high scale Rails app and MongoDB (see [blog post](https://blog.coinbase.com/scaling-connections-with-ruby-and-mongodb-99204dbf8857)). Due to Ruby MRI's global interpreter lock, multi-threaded web applications don't utilize multiple CPU cores. To achieve better CPU utilization, Puma is run with multiple workers (processes), each of which need a separate MongoDB connection pool. This leads to a large number of connections to MongoDB, sometimes exceeding MongoDB's upstream connection limit of 128k connections.

--- a/mongobetween.go
+++ b/mongobetween.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"go.uber.org/zap/zapcore"
 	"os"
 	"os/signal"
 	"sync"
@@ -16,33 +15,13 @@ import (
 
 func main() {
 	c := config.ParseFlags()
-	log := newLogger(c.LogLevel(), c.Pretty())
-	run(log, c)
+	run(c)
 }
 
-func newLogger(level zapcore.Level, pretty bool) *zap.Logger {
-	var c zap.Config
-	if pretty {
-		c = zap.NewDevelopmentConfig()
-		c.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
-	} else {
-		c = zap.NewProductionConfig()
-	}
+func run(config *config.Config) {
+	proxies, err := config.Proxies(config.Logger())
+	log := config.Logger()
 
-	c.EncoderConfig.MessageKey = "message"
-	c.Level.SetLevel(level)
-
-	log, err := c.Build(zap.AddStacktrace(zap.FatalLevel))
-	if err != nil {
-		_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize logger: %v\n", err)
-		os.Exit(1)
-	}
-
-	return log
-}
-
-func run(log *zap.Logger, config *config.Config) {
-	proxies, err := config.Proxies(log)
 	if err != nil {
 		log.Fatal("Startup error", zap.Error(err))
 	}


### PR DESCRIPTION
The idea here is to enable SDAM(Server Discovery And Monitoring) on the MongoBetween side so it can report back metrics and logs on what it observes about server and topology changes on the Atlas side.

This will be helpful for understanding the state of the cluster from MongoBetween's perspective during times of connectivity issues.

SDAM References:

https://www.alexbevi.com/blog/2022/05/15/mongodb-driver-monitoring/#go

https://github.com/mongodb/specifications/blob/a9096ad069e8af0f5973c9d0ca75da57e4c63616/source/server-discovery-and-monitoring/server-discovery-and-monitoring-monitoring.rst#events