### PR TITLE
Pin cursors to connections

### DIFF
--- a/mongo/cursor_cache.go
+++ b/mongo/cursor_cache.go
@@ -29,7 +29,7 @@ func (c *cursorCache) count() int {
 	return c.c.Len()
 }
 
-func (c *cursorCache) peek(cursorID int64, collection string) (server driver.Connection, ok bool) {
+func (c *cursorCache) peek(cursorID int64, collection string) (conn driver.Connection, ok bool) {
 
 	v, ok := c.c.Peek(buildKey(cursorID, collection))
 	if !ok {

--- a/mongo/cursor_cache.go
+++ b/mongo/cursor_cache.go
@@ -29,17 +29,17 @@ func (c *cursorCache) count() int {
 	return c.c.Len()
 }
 
-func (c *cursorCache) peek(cursorID int64, collection string) (server driver.Server, ok bool) {
+func (c *cursorCache) peek(cursorID int64, collection string) (server driver.Connection, ok bool) {
 
 	v, ok := c.c.Peek(buildKey(cursorID, collection))
 	if !ok {
 		return
 	}
-	return v.(driver.Server), true
+	return v.(driver.Connection), true
 }
 
-func (c *cursorCache) add(cursorID int64, collection string, server driver.Server) {
-	c.c.Add(buildKey(cursorID, collection), server)
+func (c *cursorCache) add(cursorID int64, collection string, conn driver.Connection) {
+	c.c.Add(buildKey(cursorID, collection), conn)
 }
 
 func (c *cursorCache) remove(cursorID int64, collection string) {

--- a/mongo/cursor_cache_test.go
+++ b/mongo/cursor_cache_test.go
@@ -6,53 +6,63 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo/address"
+	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
-type mockServer struct {
+var _ driver.Connection = &mockConnection{}
+
+type mockConnection struct {
 	i int
 }
 
-func (m *mockServer) Connection(context.Context) (driver.Connection, error) {
-	return nil, nil
-}
+func (*mockConnection) WriteWireMessage(context.Context, []byte) error  { return nil }
+func (*mockConnection) ReadWireMessage(context.Context) ([]byte, error) { return nil, nil }
+func (*mockConnection) Description() description.Server                 { return description.Server{} }
+func (*mockConnection) Close() error                                    { return nil }
+func (*mockConnection) ID() string                                      { return "" }
+func (*mockConnection) ServerConnectionID() *int64                      { return nil }
+func (*mockConnection) DriverConnectionID() uint64                      { return 0 }
+func (*mockConnection) Address() address.Address                        { return address.Address("") }
+func (*mockConnection) Stale() bool                                     { return false }
 
-func (m *mockServer) MinRTT() time.Duration {
+func (m *mockConnection) MinRTT() time.Duration {
 	return time.Duration(0)
 }
 
-func (m *mockServer) RTT90() time.Duration {
+func (m *mockConnection) RTT90() time.Duration {
 	return time.Duration(0)
 }
 
-func (m *mockServer) RTTMonitor() driver.RTTMonitor {
+func (m *mockConnection) RTTMonitor() driver.RTTMonitor {
 	return nil
 }
 
 func TestCount(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, "db.coll", &mockServer{})
-	cc.add(12, "db.coll", &mockServer{})
-	cc.add(14, "db.coll", &mockServer{})
+	cc.add(10, "db.coll", &mockConnection{})
+	cc.add(12, "db.coll", &mockConnection{})
+	cc.add(14, "db.coll", &mockConnection{})
 	assert.Equal(t, 3, cc.count())
 
-	cc.add(10, "db.coll", &mockServer{10})
+	cc.add(10, "db.coll", &mockConnection{10})
 	assert.Equal(t, 3, cc.count())
 
-	cc.add(10, "db.coll2", &mockServer{10})
+	cc.add(10, "db.coll2", &mockConnection{10})
 	assert.Equal(t, 4, cc.count())
 
 }
 
 func TestPeek(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, "db.coll", &mockServer{4})
-	cc.add(12, "db.coll", &mockServer{5})
-	cc.add(14, "db.coll", &mockServer{6})
+	cc.add(10, "db.coll", &mockConnection{4})
+	cc.add(12, "db.coll", &mockConnection{5})
+	cc.add(14, "db.coll", &mockConnection{6})
 
 	s, ok := cc.peek(12, "db.coll")
 	assert.True(t, ok)
-	assert.Equal(t, s.(*mockServer).i, 5)
+	assert.Equal(t, s.(*mockConnection).i, 5)
 
 	_, ok = cc.peek(13, "db.coll")
 	assert.False(t, ok)
@@ -60,23 +70,23 @@ func TestPeek(t *testing.T) {
 
 func TestAdd(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, "db.coll", &mockServer{4})
-	cc.add(12, "db.coll", &mockServer{5})
-	cc.add(14, "db.coll", &mockServer{6})
+	cc.add(10, "db.coll", &mockConnection{4})
+	cc.add(12, "db.coll", &mockConnection{5})
+	cc.add(14, "db.coll", &mockConnection{6})
 
 	_, ok := cc.peek(13, "db.coll")
 	assert.False(t, ok)
 
-	cc.add(13, "db.coll", &mockServer{7})
+	cc.add(13, "db.coll", &mockConnection{7})
 	_, ok = cc.peek(13, "db.coll")
 	assert.True(t, ok)
 }
 
 func TestRemove(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, "db.coll", &mockServer{4})
-	cc.add(12, "db.coll", &mockServer{5})
-	cc.add(14, "db.coll", &mockServer{6})
+	cc.add(10, "db.coll", &mockConnection{4})
+	cc.add(12, "db.coll", &mockConnection{5})
+	cc.add(14, "db.coll", &mockConnection{6})
 	assert.Equal(t, 3, cc.count())
 
 	_, ok := cc.peek(12, "db.coll")

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -187,8 +187,8 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 
 	defer func() {
 		if requestCursorID == 0 {
-			// Close the connection if the cursor has been exhuasted / there is no
-			// cursor pinned to a connection
+			// Close the connection if the cursor has been exhuasted or there is no
+			// cursor pinned to a connection.
 			err := conn.Close()
 			if err != nil {
 				m.log.Error("Error closing Mongo connection", zap.Error(err), zap.String("address", addr.String()))
@@ -233,9 +233,9 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 		if responseCursorID != 0 {
 			m.cursors.add(responseCursorID, collection, conn)
 		} else if requestCursorID != 0 {
-			// If the response cursor id is 0 and the request cursor id is non-zero,
-			// then we've exhausted the cursor and so should close and unpin the
-			// connection.
+			// If the response cursor id is zero and the request cursor id is
+			// non-zero, then we've exhausted the cursor and so should close and unpin
+			// the connection.
 			m.cursors.remove(requestCursorID, collection)
 		}
 	}

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -154,14 +154,29 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 	requestCursorID, _ := msg.Op.CursorID()
 	requestCommand, collection := msg.Op.CommandAndCollection()
 	transactionDetails := msg.Op.TransactionDetails()
-	server, err := m.selectServer(requestCursorID, collection, transactionDetails)
-	if err != nil {
-		return nil, err
+
+	var conn driver.Connection
+	var server driver.Server
+
+	if requestCursorID != 0 {
+		var ok bool
+
+		conn, ok = m.cursors.peek(requestCursorID, collection)
+		if ok {
+			m.log.Debug("Cached cursorID has been found", zap.Int64("cursor", requestCursorID), zap.String("collection", collection))
+		}
 	}
 
-	conn, err := m.checkoutConnection(server)
-	if err != nil {
-		return nil, err
+	if conn == nil {
+		server, err := m.selectServer(collection, msg.Op.TransactionDetails())
+		if err != nil {
+			return nil, err
+		}
+
+		conn, err = m.checkoutConnection(server)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	addr = conn.Address()
@@ -171,22 +186,31 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 	)
 
 	defer func() {
-		err := conn.Close()
-		if err != nil {
-			m.log.Error("Error closing Mongo connection", zap.Error(err), zap.String("address", addr.String()))
+		if requestCursorID == 0 {
+			// Close the connection if the cursor has been exhuasted / there is no
+			// cursor pinned to a connection
+			err := conn.Close()
+			if err != nil {
+				m.log.Error("Error closing Mongo connection", zap.Error(err), zap.String("address", addr.String()))
+			}
 		}
 	}()
 
 	// see https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/x/mongo/driver/operation.go#L430-L432
-	ep, ok := server.(driver.ErrorProcessor)
-	if !ok {
-		return nil, errors.New("server ErrorProcessor type assertion failed")
+	var errorProcessor driver.ErrorProcessor
+	if server != nil {
+		var ok bool
+
+		errorProcessor, ok = server.(driver.ErrorProcessor)
+		if !ok {
+			return nil, errors.New("server ErrorProcessor type assertion failed")
+		}
 	}
 
 	unacknowledged := msg.Op.Unacknowledged()
 	wm, err := m.roundTrip(conn, msg.Wm, unacknowledged, tags)
 	if err != nil {
-		m.processError(err, ep, addr, conn)
+		m.processError(err, errorProcessor, addr, conn)
 		return nil, err
 	}
 	if unacknowledged {
@@ -202,19 +226,22 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 	opErr := op.Error()
 	if opErr != nil {
 		// process the error, but don't return it as we still want to forward the response to the client
-		m.processError(opErr, ep, addr, conn)
+		m.processError(opErr, errorProcessor, addr, conn)
 	}
 
 	if responseCursorID, ok := op.CursorID(); ok {
 		if responseCursorID != 0 {
-			m.cursors.add(responseCursorID, collection, server)
+			m.cursors.add(responseCursorID, collection, conn)
 		} else if requestCursorID != 0 {
+			// If the response cursor id is 0 and the request cursor id is non-zero,
+			// then we've exhausted the cursor and so should close and unpin the
+			// connection.
 			m.cursors.remove(requestCursorID, collection)
 		}
 	}
 
 	if transactionDetails != nil {
-		if transactionDetails.IsStartTransaction {
+		if transactionDetails.IsStartTransaction && server != nil {
 			m.transactions.add(transactionDetails.LsID, server)
 		} else {
 			if requestCommand == AbortTransaction || requestCommand == CommitTransaction {
@@ -230,7 +257,7 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 	}, nil
 }
 
-func (m *Mongo) selectServer(requestCursorID int64, collection string, transDetails *TransactionDetails) (server driver.Server, err error) {
+func (m *Mongo) selectServer(collection string, transDetails *TransactionDetails) (server driver.Server, err error) {
 	defer func(start time.Time) {
 		_ = m.statsd.Timing("server_selection", time.Since(start), []string{fmt.Sprintf("success:%v", err == nil)}, 1)
 	}(time.Now())
@@ -239,15 +266,6 @@ func (m *Mongo) selectServer(requestCursorID int64, collection string, transDeta
 	if transDetails != nil {
 		if server, ok := m.transactions.peek(transDetails.LsID); ok {
 			m.log.Debug("found cached transaction", zap.String("lsid", fmt.Sprintf("%+v", transDetails)))
-			return server, nil
-		}
-	}
-
-	// Search for pinned cursor then
-	if requestCursorID != 0 {
-		server, ok := m.cursors.peek(requestCursorID, collection)
-		if ok {
-			m.log.Debug("Cached cursorID has been found", zap.Int64("cursor", requestCursorID), zap.String("collection", collection))
 			return server, nil
 		}
 	}
@@ -333,7 +351,9 @@ func (m *Mongo) processError(err error, ep driver.ErrorProcessor, addr address.A
 	}
 
 	// process the error
-	ep.ProcessError(err, conn)
+	if ep != nil {
+		ep.ProcessError(err, conn)
+	}
 
 	// log if the error changed the topology
 	if errorChangesTopology(err) {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -122,8 +122,43 @@ func TestRoundTripProcessError(t *testing.T) {
 	assert.Equal(t, description.ServerKind(description.Unknown), m.Description().Servers[0].Kind, "Failed to update the server Kind to Unknown")
 }
 
+func TestMongo_RoundTrip_NoCursorOrTxn(t *testing.T) {
+	const uri = "mongodb://127.0.0.1:8001/?loadBalanced=true"
+
+	// Create a MongoBetween client to perform mongobeteen operations in the test.
+	sd, err := statsd.New("localhost:8125")
+	assert.Nil(t, err)
+
+	clientOptions := options.Client().ApplyURI(uri).SetMaxPoolSize(10)
+	clientb, err := mongo.Connect(zap.L(), sd, clientOptions, false)
+	assert.Nil(t, err)
+
+	// Create an OP_MSG command that will respond with a non-exhausted cursor.
+	// Then extract the cursor's id from the server response.
+	cmdb, err := bson.Marshal(bson.D{
+		{"insert", "coll"}, // Collection name
+		{"$db", "simple"},  // database
+		{"ordered", true},
+	})
+
+	assert.NoError(t, err)
+
+	docByts, err := bson.Marshal(bson.D{{"x", 1}})
+	cmd := mongo.NewOpMsg(cmdb, []bsoncore.Document{docByts})
+
+	_, err = clientb.RoundTrip(cmd, []string{})
+	assert.Nil(t, err)
+
+	for i := 0; i < 50; i++ {
+		// Put msg on the wire to get cursorID and first batch.
+		_, err := clientb.RoundTrip(cmd, []string{})
+		assert.Nil(t, err)
+	}
+}
+
 func TestMongo_RoundTrip_Cursor(t *testing.T) {
 	const uri = "mongodb://127.0.0.1:8001/?loadBalanced=true"
+	const volume = 25
 
 	// Create a driver client to load test data.
 	opts := options.Client().ApplyURI(uri).SetLoadBalanced(true)
@@ -141,11 +176,14 @@ func TestMongo_RoundTrip_Cursor(t *testing.T) {
 	coll := db.Collection("simple")
 	defer func() { _ = coll.Drop(context.Background()) }()
 
-	for i := 0; i < 10; i++ {
-		_, err := coll.InsertOne(context.Background(), bson.D{{"i64", i}})
-		if err != nil {
-			log.Fatal(err)
-		}
+	docs := make([]interface{}, volume)
+	for i := 0; i < volume; i++ {
+		docs[i] = bson.D{{"i64", i}}
+	}
+
+	_, err = coll.InsertMany(context.Background(), docs)
+	if err != nil {
+		log.Fatal(err)
 	}
 
 	// Create a MongoBetween client to perform mongobeteen operations in the test.
@@ -162,7 +200,7 @@ func TestMongo_RoundTrip_Cursor(t *testing.T) {
 		{"find", "simple"}, // Collection name
 		{"$db", "cursor"},  // Database
 		{"batchSize", 1},
-		{"filter", bson.D{{"i64", bson.D{{"$lte", 25}}}}}, // Query filter
+		{"filter", bson.D{{"i64", bson.D{{"$lte", volume - 1}}}}}, // Query filter
 	})
 
 	assert.NoError(t, err)
@@ -200,9 +238,9 @@ func TestMongo_RoundTrip_Cursor(t *testing.T) {
 	getMoreCmd := mongo.NewOpMsg(getMoreb, nil)
 
 	wg := sync.WaitGroup{}
-	wg.Add(9) // Ensure every round trip completes
+	wg.Add(volume - 1) // Ensure every round trip completes
 
-	for i := 0; i < 9; i++ {
+	for i := 0; i < volume-1; i++ {
 		go func() {
 			defer wg.Done()
 
@@ -215,6 +253,7 @@ func TestMongo_RoundTrip_Cursor(t *testing.T) {
 			errCode, err := doc.LookupErr("code")
 			if err != nil {
 				return
+				//continue
 			}
 
 			errCodeI32, ok := errCode.Int32OK()

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -1,19 +1,24 @@
 package mongo_test
 
 import (
+	"context"
+	"log"
+	"os"
+	"sync"
+	"testing"
+
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/coinbase/mongobetween/mongo"
 	"github.com/coinbase/mongobetween/proxy"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	mongod "go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.uber.org/zap"
-	"os"
-	"testing"
 )
 
 func insertOpMsg(t *testing.T) *mongo.Message {
@@ -115,4 +120,108 @@ func TestRoundTripProcessError(t *testing.T) {
 	assert.Error(t, driver.Error{}, err)
 
 	assert.Equal(t, description.ServerKind(description.Unknown), m.Description().Servers[0].Kind, "Failed to update the server Kind to Unknown")
+}
+
+func TestMongo_RoundTrip_Cursor(t *testing.T) {
+	const uri = "mongodb://127.0.0.1:8001/?loadBalanced=true"
+
+	// Create a driver client to perform driver operations during the test.
+	opts := options.Client().ApplyURI(uri).SetLoadBalanced(true)
+
+	clientd, err := mongod.Connect(context.Background(), opts)
+	if err != nil {
+		log.Fatalf("failed to connect to server: %v", err)
+	}
+
+	defer func() { _ = clientd.Disconnect(context.Background()) }()
+
+	// Insert test data into the "simple" collection on the "cursor" database.
+	db := clientd.Database("cursor")
+
+	coll := db.Collection("simple")
+	defer func() { _ = coll.Drop(context.Background()) }()
+
+	for i := 0; i < 10; i++ {
+		_, err := coll.InsertOne(context.Background(), bson.D{{"i64", i}})
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// Create a MongoBetween client to perform mongobeteen operations in the test.
+	sd, err := statsd.New("localhost:8125")
+	assert.Nil(t, err)
+
+	clientOptions := options.Client().ApplyURI(uri).SetMaxPoolSize(10)
+	clientb, err := mongo.Connect(zap.L(), sd, clientOptions, false)
+	assert.Nil(t, err)
+
+	var cursorID int64
+
+	// Create a command that will respond with a non-exhausted cursor. Then
+	// extract the cursor's id from the server response.
+	cmdb, err := bson.Marshal(bson.D{
+		{"find", "simple"}, // Collection name
+		{"$db", "cursor"},  // Database
+		{"batchSize", 1},
+		{"filter", bson.D{{"i64", bson.D{{"$lte", 25}}}}}, // Query filter
+	})
+
+	assert.NoError(t, err)
+
+	cmd := mongo.NewOpMsg(cmdb, nil)
+
+	// Put msg on the wire to get cursorID and first batch.
+	res, err := clientb.RoundTrip(cmd, []string{})
+	assert.Nil(t, err)
+
+	// Extract the cursorID from the response to create a "getMore" command.
+	raw := bson.Raw(mongo.ExtractSingleOpMsg(t, res))
+
+	cursor, err := raw.LookupErr("cursor")
+	assert.NoError(t, err, "failed to lookup cursor")
+
+	cursorDoc, ok := cursor.DocumentOK()
+	assert.True(t, ok, "cursor ws not a document")
+
+	cursorIDRaw, err := cursorDoc.LookupErr("id")
+	assert.NoError(t, err, "failed to lookup cursorID")
+
+	cursorID, ok = cursorIDRaw.Int64OK()
+	assert.True(t, ok, "cursorID was not i64")
+
+	wg := sync.WaitGroup{}
+	wg.Add(9)
+
+	for i := 0; i < 9; i++ {
+		getMoreb, err := bson.Marshal(bson.D{
+			{"getMore", cursorID},
+			{"$db", "cursor"},
+			{"collection", "simple"},
+			{"batchSize", 1},
+		})
+		assert.NoError(t, err)
+
+		getMoreCmd := mongo.NewOpMsg(getMoreb, nil)
+
+		go func() {
+			defer wg.Done()
+
+			gmRes, err := clientb.RoundTrip(getMoreCmd, []string{})
+			assert.Nil(t, err)
+
+			// Make sure that the cursor does not have a "CursorNotFound" error code.
+			doc := mongo.ExtractSingleOpMsg(t, gmRes)
+
+			errCode, err := doc.LookupErr("code")
+			if err != nil {
+				return
+			}
+
+			errCodeI32, ok := errCode.Int32OK()
+			assert.False(t, ok && errCodeI32 == 43, "Cursor not found")
+		}()
+	}
+
+	wg.Wait()
 }

--- a/mongo/transaction_cache.go
+++ b/mongo/transaction_cache.go
@@ -2,9 +2,10 @@ package mongo
 
 import (
 	b64 "encoding/base64"
+	"time"
+
 	"github.com/coinbase/mongobetween/lruttl"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
-	"time"
 )
 
 // on a 64-bit machine, 1 million cursors uses around 480mb of memory
@@ -25,16 +26,16 @@ func (t *transactionCache) count() int {
 	return t.c.Len()
 }
 
-func (t *transactionCache) peek(lsID []byte) (server driver.Server, ok bool) {
+func (t *transactionCache) peek(lsID []byte) (conn driver.Connection, ok bool) {
 	v, ok := t.c.Peek(b64.StdEncoding.EncodeToString(lsID))
 	if !ok {
 		return
 	}
-	return v.(driver.Server), true
+	return v.(driver.Connection), true
 }
 
-func (t *transactionCache) add(lsID []byte, server driver.Server) {
-	t.c.Add(b64.StdEncoding.EncodeToString(lsID), server)
+func (t *transactionCache) add(lsID []byte, conn driver.Connection) {
+	t.c.Add(b64.StdEncoding.EncodeToString(lsID), conn)
 }
 
 func (t *transactionCache) remove(lsID []byte) {


### PR DESCRIPTION
The current implementation of MongoBetween uses a cursor caching solution with N >= 1 Mongos (LB7), so cursors being pinned to servers is acceptable. However, when load-balancing at the TCP layer it is not possible to target the same Mongos behind a load balancer when pooling connections (which is done under the hood in the Go Driver). This PR proposes pinning cursors and transactions to connections to account for this.