### PR TITLE
Revert "Pin cursors to connections (#70)"

### DIFF
--- a/mongo/cursor_cache.go
+++ b/mongo/cursor_cache.go
@@ -29,17 +29,17 @@ func (c *cursorCache) count() int {
 	return c.c.Len()
 }
 
-func (c *cursorCache) peek(cursorID int64, collection string) (conn driver.Connection, ok bool) {
+func (c *cursorCache) peek(cursorID int64, collection string) (server driver.Server, ok bool) {
 
 	v, ok := c.c.Peek(buildKey(cursorID, collection))
 	if !ok {
 		return
 	}
-	return v.(driver.Connection), true
+	return v.(driver.Server), true
 }
 
-func (c *cursorCache) add(cursorID int64, collection string, conn driver.Connection) {
-	c.c.Add(buildKey(cursorID, collection), conn)
+func (c *cursorCache) add(cursorID int64, collection string, server driver.Server) {
+	c.c.Add(buildKey(cursorID, collection), server)
 }
 
 func (c *cursorCache) remove(cursorID int64, collection string) {

--- a/mongo/cursor_cache_test.go
+++ b/mongo/cursor_cache_test.go
@@ -6,63 +6,53 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/mongo-driver/mongo/address"
-	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
-var _ driver.Connection = &mockConnection{}
-
-type mockConnection struct {
+type mockServer struct {
 	i int
 }
 
-func (*mockConnection) WriteWireMessage(context.Context, []byte) error  { return nil }
-func (*mockConnection) ReadWireMessage(context.Context) ([]byte, error) { return nil, nil }
-func (*mockConnection) Description() description.Server                 { return description.Server{} }
-func (*mockConnection) Close() error                                    { return nil }
-func (*mockConnection) ID() string                                      { return "" }
-func (*mockConnection) ServerConnectionID() *int64                      { return nil }
-func (*mockConnection) DriverConnectionID() uint64                      { return 0 }
-func (*mockConnection) Address() address.Address                        { return address.Address("") }
-func (*mockConnection) Stale() bool                                     { return false }
+func (m *mockServer) Connection(context.Context) (driver.Connection, error) {
+	return nil, nil
+}
 
-func (m *mockConnection) MinRTT() time.Duration {
+func (m *mockServer) MinRTT() time.Duration {
 	return time.Duration(0)
 }
 
-func (m *mockConnection) RTT90() time.Duration {
+func (m *mockServer) RTT90() time.Duration {
 	return time.Duration(0)
 }
 
-func (m *mockConnection) RTTMonitor() driver.RTTMonitor {
+func (m *mockServer) RTTMonitor() driver.RTTMonitor {
 	return nil
 }
 
 func TestCount(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, "db.coll", &mockConnection{})
-	cc.add(12, "db.coll", &mockConnection{})
-	cc.add(14, "db.coll", &mockConnection{})
+	cc.add(10, "db.coll", &mockServer{})
+	cc.add(12, "db.coll", &mockServer{})
+	cc.add(14, "db.coll", &mockServer{})
 	assert.Equal(t, 3, cc.count())
 
-	cc.add(10, "db.coll", &mockConnection{10})
+	cc.add(10, "db.coll", &mockServer{10})
 	assert.Equal(t, 3, cc.count())
 
-	cc.add(10, "db.coll2", &mockConnection{10})
+	cc.add(10, "db.coll2", &mockServer{10})
 	assert.Equal(t, 4, cc.count())
 
 }
 
 func TestPeek(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, "db.coll", &mockConnection{4})
-	cc.add(12, "db.coll", &mockConnection{5})
-	cc.add(14, "db.coll", &mockConnection{6})
+	cc.add(10, "db.coll", &mockServer{4})
+	cc.add(12, "db.coll", &mockServer{5})
+	cc.add(14, "db.coll", &mockServer{6})
 
 	s, ok := cc.peek(12, "db.coll")
 	assert.True(t, ok)
-	assert.Equal(t, s.(*mockConnection).i, 5)
+	assert.Equal(t, s.(*mockServer).i, 5)
 
 	_, ok = cc.peek(13, "db.coll")
 	assert.False(t, ok)
@@ -70,23 +60,23 @@ func TestPeek(t *testing.T) {
 
 func TestAdd(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, "db.coll", &mockConnection{4})
-	cc.add(12, "db.coll", &mockConnection{5})
-	cc.add(14, "db.coll", &mockConnection{6})
+	cc.add(10, "db.coll", &mockServer{4})
+	cc.add(12, "db.coll", &mockServer{5})
+	cc.add(14, "db.coll", &mockServer{6})
 
 	_, ok := cc.peek(13, "db.coll")
 	assert.False(t, ok)
 
-	cc.add(13, "db.coll", &mockConnection{7})
+	cc.add(13, "db.coll", &mockServer{7})
 	_, ok = cc.peek(13, "db.coll")
 	assert.True(t, ok)
 }
 
 func TestRemove(t *testing.T) {
 	cc := newCursorCache()
-	cc.add(10, "db.coll", &mockConnection{4})
-	cc.add(12, "db.coll", &mockConnection{5})
-	cc.add(14, "db.coll", &mockConnection{6})
+	cc.add(10, "db.coll", &mockServer{4})
+	cc.add(12, "db.coll", &mockServer{5})
+	cc.add(14, "db.coll", &mockServer{6})
 	assert.Equal(t, 3, cc.count())
 
 	_, ok := cc.peek(12, "db.coll")

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -153,38 +153,15 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 	// Transaction is pinned to a server by the issued lsid
 	requestCursorID, _ := msg.Op.CursorID()
 	requestCommand, collection := msg.Op.CommandAndCollection()
-	txnDetails := msg.Op.TransactionDetails()
-
-	var conn driver.Connection
-	var server driver.Server
-
-	// Check for a pinned server based on current transaction lsid first
-	if txnDetails != nil {
-		var ok bool
-
-		conn, ok = m.transactions.peek(txnDetails.LsID)
-		if ok {
-			m.log.Debug("found cached transaction", zap.String("lsid", fmt.Sprintf("%+v", txnDetails)))
-		}
-	} else if requestCursorID != 0 {
-		var ok bool
-
-		conn, ok = m.cursors.peek(requestCursorID, collection)
-		if ok {
-			m.log.Debug("Cached cursorID has been found", zap.Int64("cursor", requestCursorID), zap.String("collection", collection))
-		}
+	transactionDetails := msg.Op.TransactionDetails()
+	server, err := m.selectServer(requestCursorID, collection, transactionDetails)
+	if err != nil {
+		return nil, err
 	}
 
-	if conn == nil {
-		server, err := m.selectServer(collection)
-		if err != nil {
-			return nil, err
-		}
-
-		conn, err = m.checkoutConnection(server)
-		if err != nil {
-			return nil, err
-		}
+	conn, err := m.checkoutConnection(server)
+	if err != nil {
+		return nil, err
 	}
 
 	addr = conn.Address()
@@ -193,21 +170,23 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 		fmt.Sprintf("address:%s", conn.Address().String()),
 	)
 
-	// see https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/x/mongo/driver/operation.go#L430-L432
-	var errorProcessor driver.ErrorProcessor
-	if server != nil {
-		var ok bool
-
-		errorProcessor, ok = server.(driver.ErrorProcessor)
-		if !ok {
-			return nil, errors.New("server ErrorProcessor type assertion failed")
+	defer func() {
+		err := conn.Close()
+		if err != nil {
+			m.log.Error("Error closing Mongo connection", zap.Error(err), zap.String("address", addr.String()))
 		}
+	}()
+
+	// see https://github.com/mongodb/mongo-go-driver/blob/v1.7.2/x/mongo/driver/operation.go#L430-L432
+	ep, ok := server.(driver.ErrorProcessor)
+	if !ok {
+		return nil, errors.New("server ErrorProcessor type assertion failed")
 	}
 
 	unacknowledged := msg.Op.Unacknowledged()
 	wm, err := m.roundTrip(conn, msg.Wm, unacknowledged, tags)
 	if err != nil {
-		m.processError(err, errorProcessor, addr, conn)
+		m.processError(err, ep, addr, conn)
 		return nil, err
 	}
 	if unacknowledged {
@@ -223,49 +202,24 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 	opErr := op.Error()
 	if opErr != nil {
 		// process the error, but don't return it as we still want to forward the response to the client
-		m.processError(opErr, errorProcessor, addr, conn)
+		m.processError(opErr, ep, addr, conn)
 	}
 
-	responseCursorID, ok := op.CursorID()
-
-	defer func() {
-		// If we haven't opened a cursor and aren't in a transaction, then close
-		// the connection.
-		if conn != nil && txnDetails == nil && responseCursorID == 0 {
-			if err := conn.Close(); err != nil {
-				m.log.Error("Error closing Mongo connection", zap.Error(err), zap.String("address", addr.String()))
-			}
-		}
-	}()
-
-	if ok {
+	if responseCursorID, ok := op.CursorID(); ok {
 		if responseCursorID != 0 {
-			m.cursors.add(responseCursorID, collection, conn)
+			m.cursors.add(responseCursorID, collection, server)
 		} else if requestCursorID != 0 {
-			// If the response cursor id is zero and the request cursor id is
-			// non-zero, then we've exhausted the cursor and so should close and unpin
-			// the connection.
 			m.cursors.remove(requestCursorID, collection)
-
-			err := conn.Close()
-			if err != nil {
-				m.log.Error("Error closing Mongo connection", zap.Error(err), zap.String("address", addr.String()))
-			}
 		}
 	}
 
-	if txnDetails != nil {
-		if txnDetails.IsStartTransaction {
-			m.transactions.add(txnDetails.LsID, conn)
+	if transactionDetails != nil {
+		if transactionDetails.IsStartTransaction {
+			m.transactions.add(transactionDetails.LsID, server)
 		} else {
 			if requestCommand == AbortTransaction || requestCommand == CommitTransaction {
 				m.log.Debug("Removing transaction from the cache", zap.String("reqCommand", string(requestCommand)))
-				m.transactions.remove(txnDetails.LsID)
-
-				err := conn.Close()
-				if err != nil {
-					m.log.Error("Error closing Mongo connection", zap.Error(err), zap.String("address", addr.String()))
-				}
+				m.transactions.remove(transactionDetails.LsID)
 			}
 		}
 	}
@@ -276,10 +230,28 @@ func (m *Mongo) RoundTrip(msg *Message, tags []string) (_ *Message, err error) {
 	}, nil
 }
 
-func (m *Mongo) selectServer(collection string) (server driver.Server, err error) {
+func (m *Mongo) selectServer(requestCursorID int64, collection string, transDetails *TransactionDetails) (server driver.Server, err error) {
 	defer func(start time.Time) {
 		_ = m.statsd.Timing("server_selection", time.Since(start), []string{fmt.Sprintf("success:%v", err == nil)}, 1)
 	}(time.Now())
+
+	// Check for a pinned server based on current transaction lsid first
+	if transDetails != nil {
+		if server, ok := m.transactions.peek(transDetails.LsID); ok {
+			m.log.Debug("found cached transaction", zap.String("lsid", fmt.Sprintf("%+v", transDetails)))
+			return server, nil
+		}
+	}
+
+	// Search for pinned cursor then
+	if requestCursorID != 0 {
+		server, ok := m.cursors.peek(requestCursorID, collection)
+		if ok {
+			m.log.Debug("Cached cursorID has been found", zap.Int64("cursor", requestCursorID), zap.String("collection", collection))
+			return server, nil
+		}
+	}
+
 	// Select a server
 	selector := description.CompositeSelector([]description.ServerSelector{
 		description.ReadPrefSelector(readpref.Primary()),   // ignored by sharded clusters
@@ -361,9 +333,7 @@ func (m *Mongo) processError(err error, ep driver.ErrorProcessor, addr address.A
 	}
 
 	// process the error
-	if ep != nil {
-		ep.ProcessError(err, conn)
-	}
+	ep.ProcessError(err, conn)
 
 	// log if the error changed the topology
 	if errorChangesTopology(err) {

--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -1,24 +1,19 @@
 package mongo_test
 
 import (
-	"context"
-	"log"
-	"os"
-	"sync"
-	"testing"
-
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/coinbase/mongobetween/mongo"
 	"github.com/coinbase/mongobetween/proxy"
 	"github.com/stretchr/testify/assert"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	mongod "go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/description"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/x/bsonx/bsoncore"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.uber.org/zap"
+	"os"
+	"testing"
 )
 
 func insertOpMsg(t *testing.T) *mongo.Message {
@@ -120,193 +115,4 @@ func TestRoundTripProcessError(t *testing.T) {
 	assert.Error(t, driver.Error{}, err)
 
 	assert.Equal(t, description.ServerKind(description.Unknown), m.Description().Servers[0].Kind, "Failed to update the server Kind to Unknown")
-}
-
-func TestMongo_RoundTrip_NoCursorOrTxn(t *testing.T) {
-	const uri = "mongodb://127.0.0.1:8001/?loadBalanced=true"
-
-	// Create a MongoBetween client to perform mongobeteen operations in the test.
-	sd, err := statsd.New("localhost:8125")
-	assert.Nil(t, err)
-
-	clientOptions := options.Client().ApplyURI(uri).SetMaxPoolSize(10)
-	clientb, err := mongo.Connect(zap.L(), sd, clientOptions, false)
-	assert.Nil(t, err)
-
-	// Create a driver client for cleanup
-	t.Run("write", func(t *testing.T) {
-		t.Cleanup(func() {
-			clientd, err := mongod.Connect(context.Background(), clientOptions)
-			assert.Nil(t, err)
-
-			defer clientd.Disconnect(context.Background())
-
-			err = clientd.Database("simple").Collection("coll").Drop(context.Background())
-			assert.Nil(t, err)
-		})
-
-		// Create an OP_MSG command that will respond with a non-exhausted cursor.
-		// Then extract the cursor's id from the server response.
-		cmdb, err := bson.Marshal(bson.D{
-			{"insert", "coll"}, // Collection name
-			{"$db", "simple"},  // database
-			{"ordered", true},
-		})
-
-		assert.NoError(t, err)
-
-		docByts, err := bson.Marshal(bson.D{{"x", 1}})
-		cmd := mongo.NewOpMsg(cmdb, []bsoncore.Document{docByts})
-
-		_, err = clientb.RoundTrip(cmd, []string{})
-		assert.Nil(t, err)
-
-		for i := 0; i < 50; i++ {
-			// Put msg on the wire to get cursorID and first batch.
-			_, err := clientb.RoundTrip(cmd, []string{})
-			assert.Nil(t, err)
-		}
-	})
-
-	t.Run("read with exhausted cursor", func(t *testing.T) {
-		t.Cleanup(func() {
-			clientd, err := mongod.Connect(context.Background(), clientOptions)
-			assert.Nil(t, err)
-
-			defer clientd.Disconnect(context.Background())
-
-			err = clientd.Database("simple").Collection("coll").Drop(context.Background())
-			assert.Nil(t, err)
-		})
-
-		// Create an OP_MSG command that will respond with a non-exhausted cursor.
-		// Then extract the cursor's id from the server response.
-		cmdb, err := bson.Marshal(bson.D{
-			{"find", "coll"},  // Collection name
-			{"$db", "simple"}, // database
-			{"filter", bson.D{{"x", 1}}},
-		})
-
-		assert.NoError(t, err)
-
-		docByts, err := bson.Marshal(bson.D{{"x", 1}})
-		cmd := mongo.NewOpMsg(cmdb, []bsoncore.Document{docByts})
-
-		_, err = clientb.RoundTrip(cmd, []string{})
-		assert.Nil(t, err)
-
-		for i := 0; i < 50; i++ {
-			// Put msg on the wire to get cursorID and first batch.
-			_, err := clientb.RoundTrip(cmd, []string{})
-			assert.Nil(t, err)
-		}
-	})
-}
-
-func TestMongo_RoundTrip_Cursor(t *testing.T) {
-	const uri = "mongodb://127.0.0.1:8001/?loadBalanced=true"
-	const volume = 25
-
-	// Create a driver client to load test data.
-	opts := options.Client().ApplyURI(uri).SetLoadBalanced(true)
-
-	clientd, err := mongod.Connect(context.Background(), opts)
-	if err != nil {
-		log.Fatalf("failed to connect to server: %v", err)
-	}
-
-	defer func() { _ = clientd.Disconnect(context.Background()) }()
-
-	// Insert test data into the "simple" collection on the "cursor" database.
-	db := clientd.Database("cursor")
-
-	coll := db.Collection("simple")
-	defer func() { _ = coll.Drop(context.Background()) }()
-
-	docs := make([]interface{}, volume)
-	for i := 0; i < volume; i++ {
-		docs[i] = bson.D{{"i64", i}}
-	}
-
-	_, err = coll.InsertMany(context.Background(), docs)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// Create a MongoBetween client to perform mongobeteen operations in the test.
-	sd, err := statsd.New("localhost:8125")
-	assert.Nil(t, err)
-
-	clientOptions := options.Client().ApplyURI(uri).SetMaxPoolSize(10)
-	clientb, err := mongo.Connect(zap.L(), sd, clientOptions, false)
-	assert.Nil(t, err)
-
-	// Create an OP_MSG command that will respond with a non-exhausted cursor.
-	// Then extract the cursor's id from the server response.
-	cmdb, err := bson.Marshal(bson.D{
-		{"find", "simple"}, // Collection name
-		{"$db", "cursor"},  // Database
-		{"batchSize", 1},
-		{"filter", bson.D{{"i64", bson.D{{"$lte", volume - 1}}}}}, // Query filter
-	})
-
-	assert.NoError(t, err)
-
-	cmd := mongo.NewOpMsg(cmdb, nil)
-
-	// Put msg on the wire to get cursorID and first batch.
-	res, err := clientb.RoundTrip(cmd, []string{})
-	assert.Nil(t, err)
-
-	// Extract the cursorID from the response to create a "getMore" command.
-	raw := bson.Raw(mongo.ExtractSingleOpMsg(t, res))
-
-	cursor, err := raw.LookupErr("cursor")
-	assert.NoError(t, err, "failed to lookup cursor")
-
-	cursorDoc, ok := cursor.DocumentOK()
-	assert.True(t, ok, "cursor ws not a document")
-
-	cursorIDRaw, err := cursorDoc.LookupErr("id")
-	assert.NoError(t, err, "failed to lookup cursorID")
-
-	cursorID, ok := cursorIDRaw.Int64OK()
-	assert.True(t, ok, "cursorID was not i64")
-
-	// Create an OP_MSG "getMore" command.
-	getMoreb, err := bson.Marshal(bson.D{
-		{"getMore", cursorID},
-		{"$db", "cursor"},
-		{"collection", "simple"},
-		{"batchSize", 1},
-	})
-	assert.NoError(t, err)
-
-	getMoreCmd := mongo.NewOpMsg(getMoreb, nil)
-
-	wg := sync.WaitGroup{}
-	wg.Add(volume - 1) // Ensure every round trip completes
-
-	for i := 0; i < volume-1; i++ {
-		go func() {
-			defer wg.Done()
-
-			gmRes, err := clientb.RoundTrip(getMoreCmd, []string{})
-			assert.Nil(t, err)
-
-			// Make sure that the cursor does not have a "CursorNotFound" error code.
-			doc := mongo.ExtractSingleOpMsg(t, gmRes)
-
-			errCode, err := doc.LookupErr("code")
-			if err != nil {
-				return
-				//continue
-			}
-
-			errCodeI32, ok := errCode.Int32OK()
-			assert.False(t, ok && errCodeI32 == 43, "Cursor not found")
-		}()
-	}
-
-	wg.Wait()
 }

--- a/mongo/transaction_cache.go
+++ b/mongo/transaction_cache.go
@@ -2,10 +2,9 @@ package mongo
 
 import (
 	b64 "encoding/base64"
-	"time"
-
 	"github.com/coinbase/mongobetween/lruttl"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
+	"time"
 )
 
 // on a 64-bit machine, 1 million cursors uses around 480mb of memory
@@ -26,16 +25,16 @@ func (t *transactionCache) count() int {
 	return t.c.Len()
 }
 
-func (t *transactionCache) peek(lsID []byte) (conn driver.Connection, ok bool) {
+func (t *transactionCache) peek(lsID []byte) (server driver.Server, ok bool) {
 	v, ok := t.c.Peek(b64.StdEncoding.EncodeToString(lsID))
 	if !ok {
 		return
 	}
-	return v.(driver.Connection), true
+	return v.(driver.Server), true
 }
 
-func (t *transactionCache) add(lsID []byte, conn driver.Connection) {
-	t.c.Add(b64.StdEncoding.EncodeToString(lsID), conn)
+func (t *transactionCache) add(lsID []byte, server driver.Server) {
+	t.c.Add(b64.StdEncoding.EncodeToString(lsID), server)
 }
 
 func (t *transactionCache) remove(lsID []byte) {

--- a/mongo/transaction_cache_test.go
+++ b/mongo/transaction_cache_test.go
@@ -3,50 +3,56 @@ package mongo
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.mongodb.org/mongo-driver/mongo/address"
-	"go.mongodb.org/mongo-driver/mongo/description"
+	"go.mongodb.org/mongo-driver/x/mongo/driver"
 )
 
-type txnMockConnection struct {
+type transactionMockServer struct {
 	i int
 }
 
-func (*txnMockConnection) WriteWireMessage(context.Context, []byte) error  { return nil }
-func (*txnMockConnection) ReadWireMessage(context.Context) ([]byte, error) { return nil, nil }
-func (*txnMockConnection) Description() description.Server                 { return description.Server{} }
-func (*txnMockConnection) Close() error                                    { return nil }
-func (*txnMockConnection) ID() string                                      { return "" }
-func (*txnMockConnection) ServerConnectionID() *int64                      { return nil }
-func (*txnMockConnection) DriverConnectionID() uint64                      { return 0 }
-func (*txnMockConnection) Address() address.Address                        { return address.Address("") }
-func (*txnMockConnection) Stale() bool                                     { return false }
+func (m *transactionMockServer) MinRTT() time.Duration {
+	return time.Duration(0)
+}
+
+func (m *transactionMockServer) RTT90() time.Duration {
+	return time.Duration(0)
+}
+
+func (m *transactionMockServer) Connection(context.Context) (driver.Connection, error) {
+	return nil, nil
+}
+
+func (m *transactionMockServer) RTTMonitor() driver.RTTMonitor {
+	return nil
+}
 
 func TestTransactionCacheCount(t *testing.T) {
 	tc := newTransactionCache()
-	tc.add([]byte{0x1}, &txnMockConnection{})
-	tc.add([]byte{0x2}, &txnMockConnection{})
-	tc.add([]byte{0x3}, &txnMockConnection{})
+	tc.add([]byte{0x1}, &transactionMockServer{})
+	tc.add([]byte{0x2}, &transactionMockServer{})
+	tc.add([]byte{0x3}, &transactionMockServer{})
 	assert.Equal(t, 3, tc.count())
 
-	tc.add([]byte{0x1}, &txnMockConnection{10})
+	tc.add([]byte{0x1}, &transactionMockServer{10})
 	assert.Equal(t, 3, tc.count())
 
-	tc.add([]byte{0x10}, &txnMockConnection{10})
+	tc.add([]byte{0x10}, &transactionMockServer{10})
 	assert.Equal(t, 4, tc.count())
 
 }
 
 func TestTransactionCachePeek(t *testing.T) {
 	tc := newTransactionCache()
-	tc.add([]byte{0x10}, &txnMockConnection{4})
-	tc.add([]byte{0x12}, &txnMockConnection{5})
-	tc.add([]byte{0x14}, &txnMockConnection{6})
+	tc.add([]byte{0x10}, &transactionMockServer{4})
+	tc.add([]byte{0x12}, &transactionMockServer{5})
+	tc.add([]byte{0x14}, &transactionMockServer{6})
 
 	s, ok := tc.peek([]byte{0x12})
 	assert.True(t, ok)
-	assert.Equal(t, s.(*txnMockConnection).i, 5)
+	assert.Equal(t, s.(*transactionMockServer).i, 5)
 
 	_, ok = tc.peek([]byte{0x13})
 	assert.False(t, ok)
@@ -54,23 +60,23 @@ func TestTransactionCachePeek(t *testing.T) {
 
 func TestTransactionCacheAdd(t *testing.T) {
 	tc := newTransactionCache()
-	tc.add([]byte{0x10}, &txnMockConnection{4})
-	tc.add([]byte{0x12}, &txnMockConnection{5})
-	tc.add([]byte{0x14}, &txnMockConnection{6})
+	tc.add([]byte{0x10}, &transactionMockServer{4})
+	tc.add([]byte{0x12}, &transactionMockServer{5})
+	tc.add([]byte{0x14}, &transactionMockServer{6})
 
 	_, ok := tc.peek([]byte{0x13})
 	assert.False(t, ok)
 
-	tc.add([]byte{0x13}, &txnMockConnection{7})
+	tc.add([]byte{0x13}, &transactionMockServer{7})
 	_, ok = tc.peek([]byte{0x13})
 	assert.True(t, ok)
 }
 
 func TestTransactionTestRemove(t *testing.T) {
 	tc := newTransactionCache()
-	tc.add([]byte{0x10}, &txnMockConnection{4})
-	tc.add([]byte{0x12}, &txnMockConnection{5})
-	tc.add([]byte{0x14}, &txnMockConnection{6})
+	tc.add([]byte{0x10}, &transactionMockServer{4})
+	tc.add([]byte{0x12}, &transactionMockServer{5})
+	tc.add([]byte{0x14}, &transactionMockServer{6})
 	assert.Equal(t, 3, tc.count())
 
 	_, ok := tc.peek([]byte{0x12})


### PR DESCRIPTION
This reverts commit db55bae39e1516cedbbd694f9c2d413629bd3ce5.

We've found a regression where mongobetween will start to choke when a bunch of huge, slow queries are being thrown at it. We're reverting this PR for now, and revisiting once we root cause the issue.