### PR TITLE
Subset connections that can be pinned

### DIFF
--- a/mongo/mongo_test.go
+++ b/mongo/mongo_test.go
@@ -101,17 +101,11 @@ func TestRoundTripStuckPool(t *testing.T) {
 	assert.NoError(t, err)
 	cmd := mongo.NewOpMsg(cmdb, nil)
 
-	// Send message 3 times to exhaust pool with checked out connections.
-	numExecutions := 3
-	for i := 0; i < numExecutions; i++ {
-		_, err = m.RoundTrip(cmd, []string{})
-		assert.Nil(t, err)
-	}
-
-	// TODO: Remove this log once issue is fixed.
-	t.Log("This below invocation will be block due to pool exhaustion.")
 	_, err = m.RoundTrip(cmd, []string{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
+
+	_, err = m.RoundTrip(cmd, []string{})
+	assert.Error(t, mongo.ErrMaxedReserve)
 }
 
 func TestRoundTripProcessError(t *testing.T) {


### PR DESCRIPTION
This PR proposes proper subsetting the number of connections that can be pinned to cursors. If $N$ is the max pool size and $n$ is the max cache size, we would want $n < N - 1$ : shimming 1 connection for propagating `ErrMaxReserve`. That is, if we are at $n$ cursors pinned, then after each round trip check to see if the response has a cursorID. If so, then close the connection and propagate the error: "cursor could not be pinned to connection: maxed out reserve". This ensures that `N-n-1` connections are always available.