### PR TITLE
test: resolve remaining linter errors on build

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+issues:
+  exclude-rules:
+    # these operations are deprecated, and we properly parse the replacement message type, but
+    # support remains for the deprecated form of encoding
+    - path: mongo/operations.go
+      text: "SA1019: wiremessage.ReadQuery"
+    - path: mongo/operations.go
+      text: "SA1019: wiremessage.OpQuery"

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -108,7 +108,7 @@ func TestProxyUnacknowledgedWrites(t *testing.T) {
 
 	// Create two *Collection instances: one for setup and basic operations and and one configured with an
 	// unacknowledged write concern for testing.
-	wc := writeconcern.New(writeconcern.W(0))
+	wc := writeconcern.Unacknowledged()
 	setupCollection := client.Database("test").Collection("test_proxy_unacknowledged_writes")
 	unackCollection, err := setupCollection.Clone(options.Collection().SetWriteConcern(wc))
 	assert.Nil(t, err)


### PR DESCRIPTION
This change resolves two kinds of linter errors that were surfaced in yesterday's GitHub Actions migration.

1. suppresses linter warnings about the use of the Query message representation in protobuf. We already support the replacement type and our use-case makes sense to remain backwards compatible.
1. use new non-deprecated api in proxy test case

We should now have a build that passes all checks.
